### PR TITLE
AttenderAnswer 통합 테스트 일부가 실패하는 문제 해결

### DIFF
--- a/src/test/java/kr/pullgo/pullgoserver/AttenderAnswerIntegrationTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/AttenderAnswerIntegrationTest.java
@@ -291,7 +291,7 @@ public class AttenderAnswerIntegrationTest {
             .answer(new Answer(4, 5, 6))
             .build();
 
-        AttenderState attenderState = createAttenderState();
+        AttenderState attenderState = createAndSaveAttenderState();
         attenderState.addAnswer(attenderAnswer);
 
         Question question = createAndSaveQuestion();


### PR DESCRIPTION
기존에 `org.hibernate.TransientPropertyValueException: object references an unsaved transient instance` 문제가 발생함
AttenderAnswer에 Transient 상태의 AttenderState가 넣어진 상태로 영속화할 때, AttenderAnswer가 AttenderState로 엉속성을 전이시키는 구조가 아니므로 영속화 수행에 실패함
따라서 AttenderAnswer에 이미 영속화된 AttenderState를 주입시키는 방향으로 해결함