### PR TITLE
수업 목록 조회 API에 날짜 기준으로 조회하는 쿼리 패러미터 추가

### DIFF
--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -562,6 +562,10 @@ operation::lesson-list-example[snippets='request-parameters,curl-request,http-re
 
 <<resources_lesson_list, Lesson 목록 조회 API>>에 요청 패러미터를 추가하면 특정 조건을 기준으로 Lesson을 검색할 수 있습니다.
 
+`sinceDate` 와 `untilDate` 로 검색하는 Lesson의 수업 날짜를 제한할 수 있습니다.
+이때, `untilDate` 는 제외적(exclusive)으로 작동합니다.
+가령 `untilDate=2021-05-01` 인자로 검색하면, 5월 1일의 수업은 포함되지 않으며, 4월 30일의 수업까지만 포함됩니다.
+
 operation::lesson-search-example[snippets='request-parameters,curl-request,http-response']
 
 [[resources_lesson_create]]

--- a/src/main/java/kr/pullgo/pullgoserver/presentation/controller/LessonController.java
+++ b/src/main/java/kr/pullgo/pullgoserver/presentation/controller/LessonController.java
@@ -1,5 +1,6 @@
 package kr.pullgo.pullgoserver.presentation.controller;
 
+import java.time.LocalDate;
 import java.util.List;
 import javax.validation.Valid;
 import kr.pullgo.pullgoserver.dto.LessonDto;
@@ -9,6 +10,7 @@ import kr.pullgo.pullgoserver.service.spec.LessonSpecs;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -41,6 +43,8 @@ public class LessonController {
         @RequestParam(required = false) Long classroomId,
         @RequestParam(required = false) Long studentId,
         @RequestParam(required = false) Long teacherId,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate sinceDate,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate untilDate,
         Pageable pageable
     ) {
         Specification<Lesson> spec = null;
@@ -52,6 +56,12 @@ public class LessonController {
         }
         if (teacherId != null) {
             spec = LessonSpecs.isAssignedToTeacher(teacherId).and(spec);
+        }
+        if (sinceDate != null) {
+            spec = LessonSpecs.sinceDate(sinceDate).and(spec);
+        }
+        if (untilDate != null) {
+            spec = LessonSpecs.untilDate(untilDate).and(spec);
         }
 
         return lessonService.search(spec, pageable);

--- a/src/main/java/kr/pullgo/pullgoserver/service/spec/LessonSpecs.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/spec/LessonSpecs.java
@@ -1,8 +1,10 @@
 package kr.pullgo.pullgoserver.service.spec;
 
+import java.time.LocalDate;
 import javax.persistence.criteria.Join;
 import kr.pullgo.pullgoserver.persistence.model.Classroom;
 import kr.pullgo.pullgoserver.persistence.model.Lesson;
+import kr.pullgo.pullgoserver.persistence.model.Schedule;
 import kr.pullgo.pullgoserver.persistence.model.Student;
 import kr.pullgo.pullgoserver.persistence.model.Teacher;
 import org.springframework.data.jpa.domain.Specification;
@@ -29,6 +31,20 @@ public class LessonSpecs {
             Join<Lesson, Classroom> classroom = root.join("classroom");
             Join<Classroom, Teacher> teachers = classroom.joinSet("teachers");
             return builder.equal(teachers.get("id"), teacherId);
+        };
+    }
+
+    public static Specification<Lesson> sinceDate(LocalDate begin) {
+        return (root, query, builder) -> {
+            Join<Lesson, Schedule> schedule = root.join("schedule");
+            return builder.greaterThanOrEqualTo(schedule.get("date"), begin);
+        };
+    }
+
+    public static Specification<Lesson> untilDate(LocalDate endExclusive) {
+        return (root, query, builder) -> {
+            Join<Lesson, Schedule> schedule = root.join("schedule");
+            return builder.lessThan(schedule.get("date"), endExclusive);
         };
     }
 


### PR DESCRIPTION
close #89 

`sinceDate`와 `untilDate` 인자로 구현함

`untilDate`는 exclusive하게 기능하도록 했음
* 자기 자신은 포함하지 않는 범위
  * e.g. `untilDate=2021-05-01`: 4월 31일까지 포함, 5월 1일은 포함하지 않음
* 이렇게 만들면 API 사용이 조금 더 편리해짐
  * 예시로, 4월 한 달의 모든 Lesson을 조회해야 할 때, 끝 범위가 exclusive하지 않으면 4월 1일부터 4월 30일까지 쿼리해야 함
    * 이때 클라이언트 개발자는 4월의 마지막 날이 30일이라는 사실을 계산해야 함
  * 끝 범위를 exclusive하게 만들면, 4월 1일부터 5월 1일까지 쿼리하면 됨
    * 클라이언트 개발자는 month에 1만 더하면 끝 범위를 계산할 수 있음