### PR TITLE
인증과 인가 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
     asciidoctor 'org.springframework.restdocs:spring-restdocs-asciidoctor:2.0.5.RELEASE'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:2.0.5.RELEASE'
+    compile 'io.jsonwebtoken:jjwt-api:0.11.2'
+    runtime 'io.jsonwebtoken:jjwt-impl:0.11.2', 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 }
 
 ext {

--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -14,11 +14,9 @@ WARNING: 이 API는 아직 구현 중에 있으며 추후에 변경될 수 있�
 ****
 다음 기능은 아직 미구현 상태입니다:
 
-* 회원가입과 로그인 API
+* 휴대폰 인증을 포함한 회원가입 API (현재 휴대폰 인증 없이 회원가입이 가능함)
 * 시험 결과를 응시자 부모의 전화번호로 전송하는 API
 * 사진과 함께 시험 문제를 생성하는 API
-* API 호출 시 사용자 신분과 권한 확인 (지금은 모두 관리자 권한을 가짐)
-* 요청으로 전달한 인자 값 유효성 검증
 ****
 
 [[overview]]
@@ -227,6 +225,36 @@ include::{snippets}/academy-list-with-paging-example/response-body.adoc[]
 
 [[resources]]
 = Resources
+
+[[resources_auth]]
+== Auth 리소스
+
+[[resources_auth_token]]
+=== 액세스 토큰 발급
+
+사용자 이름과 비밀번호를 담은 `POST /auth/token` 요청으로 액세스 토큰(JWT)을 발급합니다.
+
+액세스 토큰은 사용자 이름과 비밀번호를 대신할 인증 수단으로, API 호출 시 요청 헤더에 기입하여 사용합니다.
+
+리소스 조작 등 권한이 필요한 API들을 호출할 때 요청 헤더로 액세스 토큰을 제공해야 합니다.
+헤더 형식은 다음과 같습니다:
+
+ Authorization: Bearer ACCESS_TOKEN_HERE
+
+사용자 인증에 실패하면 `401 Unauthorized`, 리소스에 대한 권한이 없으면 `403 Forbidden` 상태 코드를 반환합니다.
+
+액세스 토큰은 보안을 위해 만료 기한이 존재하며, 만료된 토큰으로 요청하면 `401 Unauthorized` 상태 코드가 반환됩니다.
+따라서 클라이언트 개발자는 토큰 만료 시 사용자에게 로그인 페이지를 안내해야 합니다.
+
+operation::auth-generate-token-example[snippets='request-fields,response-fields,curl-request,http-response']
+
+[[resources_auth_me]]
+=== 사용자 신원 조회
+
+`POST /auth/me` 요청으로 토큰을 소유한 사용자의 신원 정보를 조회합니다.
+요청의 `Authorization` 헤더로 엑세스 토큰이 제공되어야 합니다.
+
+operation::auth-me-example[snippets='response-fields,curl-request,http-response']
 
 [[resources_academy]]
 == Academy 리소스

--- a/src/main/java/kr/pullgo/pullgoserver/config/SecurityConfig.java
+++ b/src/main/java/kr/pullgo/pullgoserver/config/SecurityConfig.java
@@ -1,9 +1,12 @@
 package kr.pullgo.pullgoserver.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 @EnableWebSecurity
@@ -13,5 +16,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
         http
             .csrf().disable();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/kr/pullgo/pullgoserver/config/security/BearerTokenAuthenticationFilter.java
+++ b/src/main/java/kr/pullgo/pullgoserver/config/security/BearerTokenAuthenticationFilter.java
@@ -1,0 +1,29 @@
+package kr.pullgo.pullgoserver.config.security;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class BearerTokenAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String PREFIX_BEARER = "Bearer ";
+    public static final String HEADER_AUTHORIZATION = "Authorization";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws IOException, ServletException {
+        String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
+        if (authorizationHeader != null && authorizationHeader.startsWith(PREFIX_BEARER)) {
+            String token = authorizationHeader.replace(PREFIX_BEARER, "");
+            Authentication authentication = new JwtAuthenticationToken(token);
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/kr/pullgo/pullgoserver/config/security/JwtAuthenticationProvider.java
+++ b/src/main/java/kr/pullgo/pullgoserver/config/security/JwtAuthenticationProvider.java
@@ -1,0 +1,57 @@
+package kr.pullgo.pullgoserver.config.security;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import java.util.List;
+import kr.pullgo.pullgoserver.persistence.model.Account;
+import kr.pullgo.pullgoserver.persistence.repository.AccountRepository;
+import kr.pullgo.pullgoserver.service.JwtService;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+
+    private final JwtService jwtService;
+    private final AccountRepository accountRepository;
+
+    public JwtAuthenticationProvider(
+        JwtService jwtService,
+        AccountRepository accountRepository) {
+        this.jwtService = jwtService;
+        this.accountRepository = accountRepository;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication)
+        throws AuthenticationException {
+        SecurityContext context = SecurityContextHolder.getContext();
+        JwtAuthenticationToken auth = (JwtAuthenticationToken) context.getAuthentication();
+
+        String token = auth.getToken();
+        UserPrincipal principal;
+        try {
+            principal = jwtService.extractSubject(token);
+        } catch (ExpiredJwtException | UnsupportedJwtException
+            | MalformedJwtException | SignatureException ex) {
+            throw new BadCredentialsException(ex.getMessage());
+        }
+
+        Account account = accountRepository.findById(principal.getAccountId())
+            .orElseThrow(() -> new BadCredentialsException("Account not found"));
+
+        List<GrantedAuthority> authorities = List.of(account.getRole().asAuthority());
+        return new UserPrincipalAuthenticationToken(principal, authorities);
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return authentication == JwtAuthenticationToken.class;
+    }
+}

--- a/src/main/java/kr/pullgo/pullgoserver/config/security/JwtAuthenticationToken.java
+++ b/src/main/java/kr/pullgo/pullgoserver/config/security/JwtAuthenticationToken.java
@@ -1,0 +1,29 @@
+package kr.pullgo.pullgoserver.config.security;
+
+import java.util.Collections;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final String token;
+
+    public JwtAuthenticationToken(String token) {
+        super(Collections.emptyList());
+        this.token = token;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    @Override
+    public String getPrincipal() {
+        return getToken();
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+}

--- a/src/main/java/kr/pullgo/pullgoserver/config/security/SecurityConfig.java
+++ b/src/main/java/kr/pullgo/pullgoserver/config/security/SecurityConfig.java
@@ -1,4 +1,4 @@
-package kr.pullgo.pullgoserver.config;
+package kr.pullgo.pullgoserver.config.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/kr/pullgo/pullgoserver/config/security/SecurityConfig.java
+++ b/src/main/java/kr/pullgo/pullgoserver/config/security/SecurityConfig.java
@@ -1,25 +1,49 @@
 package kr.pullgo.pullgoserver.config.security;
 
+import kr.pullgo.pullgoserver.persistence.repository.AccountRepository;
+import kr.pullgo.pullgoserver.service.JwtService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
+    private final JwtService jwtService;
+    private final AccountRepository accountRepository;
+
+    @Autowired
+    public SecurityConfig(JwtService jwtService,
+        AccountRepository accountRepository) {
+        this.jwtService = jwtService;
+        this.accountRepository = accountRepository;
+    }
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) {
+        auth.authenticationProvider(new JwtAuthenticationProvider(jwtService, accountRepository));
+    }
+
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
-            .csrf().disable();
+            .csrf().disable()
+            .addFilterBefore(new BearerTokenAuthenticationFilter(),
+                BasicAuthenticationFilter.class)
+            .authorizeRequests().anyRequest().permitAll();
     }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
+
 }

--- a/src/main/java/kr/pullgo/pullgoserver/config/security/UserPrincipal.java
+++ b/src/main/java/kr/pullgo/pullgoserver/config/security/UserPrincipal.java
@@ -1,0 +1,18 @@
+package kr.pullgo.pullgoserver.config.security;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserPrincipal {
+
+    private final Long accountId;
+    private final String username;
+
+    @Builder
+    public UserPrincipal(Long accountId, String username) {
+        this.accountId = accountId;
+        this.username = username;
+    }
+
+}

--- a/src/main/java/kr/pullgo/pullgoserver/config/security/UserPrincipalAuthenticationToken.java
+++ b/src/main/java/kr/pullgo/pullgoserver/config/security/UserPrincipalAuthenticationToken.java
@@ -1,0 +1,27 @@
+package kr.pullgo.pullgoserver.config.security;
+
+import java.util.Collection;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+public class UserPrincipalAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final UserPrincipal principal;
+
+    public UserPrincipalAuthenticationToken(UserPrincipal principal,
+        Collection<GrantedAuthority> authorities) {
+        super(authorities);
+        this.principal = principal;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return principal;
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+}

--- a/src/main/java/kr/pullgo/pullgoserver/dto/AccountDto.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/AccountDto.java
@@ -1,6 +1,7 @@
 package kr.pullgo.pullgoserver.dto;
 
 import javax.validation.constraints.NotNull;
+import kr.pullgo.pullgoserver.persistence.model.UserRole;
 import lombok.Builder;
 import lombok.Data;
 import lombok.With;
@@ -50,5 +51,8 @@ public interface AccountDto {
 
         @NotNull
         private String phone;
+
+        @NotNull
+        private UserRole role;
     }
 }

--- a/src/main/java/kr/pullgo/pullgoserver/dto/AuthDto.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/AuthDto.java
@@ -1,0 +1,44 @@
+package kr.pullgo.pullgoserver.dto;
+
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+
+public interface AuthDto {
+
+    @Data
+    @Builder
+    class GenerateToken {
+
+        @NotNull
+        private String username;
+
+        @NotNull
+        private String password;
+
+    }
+
+    @Data
+    @Builder
+    class GenerateTokenResult {
+
+        @NotNull
+        private String token;
+
+        private StudentDto.Result student;
+
+        private TeacherDto.Result teacher;
+
+    }
+
+    @Data
+    @Builder
+    class MeResult {
+
+        private StudentDto.Result student;
+
+        private TeacherDto.Result teacher;
+
+    }
+
+}

--- a/src/main/java/kr/pullgo/pullgoserver/dto/mapper/AccountDtoMapper.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/mapper/AccountDtoMapper.java
@@ -23,6 +23,7 @@ public class AccountDtoMapper implements DtoMapper<Account, AccountDto.Create, A
             .username(account.getUsername())
             .fullName(account.getFullName())
             .phone(account.getPhone())
+            .role(account.getRole())
             .build();
     }
 

--- a/src/main/java/kr/pullgo/pullgoserver/persistence/model/Account.java
+++ b/src/main/java/kr/pullgo/pullgoserver/persistence/model/Account.java
@@ -2,6 +2,8 @@ package kr.pullgo.pullgoserver.persistence.model;
 
 import com.sun.istack.NotNull;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -39,11 +41,16 @@ public class Account extends TimeEntity {
     @NotNull
     private String phone;
 
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private UserRole role;
+
     @Builder
-    public Account(String username, String password, String fullName, String phone) {
+    public Account(String username, String password, String fullName, String phone, UserRole role) {
         this.username = username;
         this.password = password;
         this.fullName = fullName;
         this.phone = phone;
+        this.role = role;
     }
 }

--- a/src/main/java/kr/pullgo/pullgoserver/persistence/model/UserRole.java
+++ b/src/main/java/kr/pullgo/pullgoserver/persistence/model/UserRole.java
@@ -1,0 +1,5 @@
+package kr.pullgo.pullgoserver.persistence.model;
+
+public enum UserRole {
+    USER, ADMIN
+}

--- a/src/main/java/kr/pullgo/pullgoserver/persistence/model/UserRole.java
+++ b/src/main/java/kr/pullgo/pullgoserver/persistence/model/UserRole.java
@@ -1,5 +1,12 @@
 package kr.pullgo.pullgoserver.persistence.model;
 
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
 public enum UserRole {
-    USER, ADMIN
+    USER, ADMIN;
+
+    public GrantedAuthority asAuthority() {
+        return new SimpleGrantedAuthority(this.name());
+    }
 }

--- a/src/main/java/kr/pullgo/pullgoserver/persistence/repository/AccountRepository.java
+++ b/src/main/java/kr/pullgo/pullgoserver/persistence/repository/AccountRepository.java
@@ -1,9 +1,12 @@
 package kr.pullgo.pullgoserver.persistence.repository;
 
+import java.util.Optional;
 import kr.pullgo.pullgoserver.persistence.model.Account;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AccountRepository extends BaseRepository<Account, Long> {
+
+    Optional<Account> findByUsername(String username);
 
 }

--- a/src/main/java/kr/pullgo/pullgoserver/persistence/repository/StudentRepository.java
+++ b/src/main/java/kr/pullgo/pullgoserver/persistence/repository/StudentRepository.java
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface StudentRepository extends BaseRepository<Student, Long> {
 
+    Student findByAccountId(Long accountId);
+
 }

--- a/src/main/java/kr/pullgo/pullgoserver/persistence/repository/TeacherRepository.java
+++ b/src/main/java/kr/pullgo/pullgoserver/persistence/repository/TeacherRepository.java
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface TeacherRepository extends BaseRepository<Teacher, Long> {
 
+    Teacher findByAccountId(Long accountId);
+
 }

--- a/src/main/java/kr/pullgo/pullgoserver/presentation/controller/AcademyController.java
+++ b/src/main/java/kr/pullgo/pullgoserver/presentation/controller/AcademyController.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -71,46 +72,49 @@ public class AcademyController {
 
     @PostMapping("/academies")
     @ResponseStatus(HttpStatus.CREATED)
-    public AcademyDto.Result post(@Valid @RequestBody AcademyDto.Create dto) {
-        return academyService.create(dto);
+    public AcademyDto.Result post(@Valid @RequestBody AcademyDto.Create dto,
+        Authentication authentication) {
+        return academyService.create(dto, authentication);
     }
 
     @PatchMapping("/academies/{id}")
     public AcademyDto.Result patch(@PathVariable Long id,
-        @Valid @RequestBody AcademyDto.Update dto) {
-        return academyService.update(id, dto);
+        @Valid @RequestBody AcademyDto.Update dto, Authentication authentication) {
+        return academyService.update(id, dto, authentication);
     }
 
     @DeleteMapping("/academies/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable Long id) {
-        academyService.delete(id);
+    public void delete(@PathVariable Long id, Authentication authentication) {
+        academyService.delete(id, authentication);
     }
 
     @PostMapping("/academies/{id}/accept-teacher")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void acceptTeacher(@PathVariable Long id,
-        @Valid @RequestBody AcademyDto.AcceptTeacher dto) {
-        academyService.acceptTeacher(id, dto);
+        @Valid @RequestBody AcademyDto.AcceptTeacher dto, Authentication authentication) {
+        academyService.acceptTeacher(id, dto, authentication);
     }
 
     @PostMapping("/academies/{id}/kick-teacher")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void kickTeacher(@PathVariable Long id, @Valid @RequestBody AcademyDto.KickTeacher dto) {
-        academyService.kickTeacher(id, dto);
+    public void kickTeacher(@PathVariable Long id, @Valid @RequestBody AcademyDto.KickTeacher dto,
+        Authentication authentication) {
+        academyService.kickTeacher(id, dto, authentication);
     }
 
 
     @PostMapping("/academies/{id}/accept-student")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void acceptStudent(@PathVariable Long id,
-        @Valid @RequestBody AcademyDto.AcceptStudent dto) {
-        academyService.acceptStudent(id, dto);
+        @Valid @RequestBody AcademyDto.AcceptStudent dto, Authentication authentication) {
+        academyService.acceptStudent(id, dto, authentication);
     }
 
     @PostMapping("/academies/{id}/kick-student")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void kickStudent(@PathVariable Long id, @Valid @RequestBody AcademyDto.KickStudent dto) {
-        academyService.kickStudent(id, dto);
+    public void kickStudent(@PathVariable Long id, @Valid @RequestBody AcademyDto.KickStudent dto,
+        Authentication authentication) {
+        academyService.kickStudent(id, dto, authentication);
     }
 }

--- a/src/main/java/kr/pullgo/pullgoserver/presentation/controller/AttenderAnswerController.java
+++ b/src/main/java/kr/pullgo/pullgoserver/presentation/controller/AttenderAnswerController.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -33,8 +34,9 @@ public class AttenderAnswerController {
 
     @PostMapping("/exam/attender-state/answers")
     @ResponseStatus(HttpStatus.CREATED)
-    public AttenderAnswerDto.Result post(@Valid @RequestBody AttenderAnswerDto.Create dto) {
-        return attenderAnswerService.create(dto);
+    public AttenderAnswerDto.Result post(@Valid @RequestBody AttenderAnswerDto.Create dto,
+        Authentication authentication) {
+        return attenderAnswerService.create(dto, authentication);
     }
 
     @GetMapping("/exam/attender-state/answers")
@@ -57,14 +59,14 @@ public class AttenderAnswerController {
 
     @DeleteMapping("/exam/attender-state/answers/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable Long id) {
-        attenderAnswerService.delete(id);
+    public void delete(@PathVariable Long id, Authentication authentication) {
+        attenderAnswerService.delete(id, authentication);
     }
 
     @PatchMapping("/exam/attender-state/answers/{id}")
     public AttenderAnswerDto.Result patch(@PathVariable Long id,
-        @Valid @RequestBody AttenderAnswerDto.Update dto) {
-        return attenderAnswerService.update(id, dto);
+        @Valid @RequestBody AttenderAnswerDto.Update dto, Authentication authentication) {
+        return attenderAnswerService.update(id, dto, authentication);
     }
 
 }

--- a/src/main/java/kr/pullgo/pullgoserver/presentation/controller/AttenderStateController.java
+++ b/src/main/java/kr/pullgo/pullgoserver/presentation/controller/AttenderStateController.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -33,8 +34,9 @@ public class AttenderStateController {
 
     @PostMapping("/exam/attender-states")
     @ResponseStatus(HttpStatus.CREATED)
-    public AttenderStateDto.Result post(@Valid @RequestBody AttenderStateDto.Create dto) {
-        return attenderStateService.create(dto);
+    public AttenderStateDto.Result post(@Valid @RequestBody AttenderStateDto.Create dto,
+        Authentication authentication) {
+        return attenderStateService.create(dto, authentication);
     }
 
     @GetMapping("/exam/attender-states")
@@ -61,19 +63,19 @@ public class AttenderStateController {
 
     @DeleteMapping("/exam/attender-states/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable Long id) {
-        attenderStateService.delete(id);
+    public void delete(@PathVariable Long id, Authentication authentication) {
+        attenderStateService.delete(id, authentication);
     }
 
     @PatchMapping("/exam/attender-states/{id}")
     public AttenderStateDto.Result patch(@PathVariable Long id,
-        @Valid @RequestBody AttenderStateDto.Update dto) {
-        return attenderStateService.update(id, dto);
+        @Valid @RequestBody AttenderStateDto.Update dto, Authentication authentication) {
+        return attenderStateService.update(id, dto, authentication);
     }
 
     @PostMapping("/exam/attender-states/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void submit(@PathVariable Long id) {
-        attenderStateService.submit(id);
+    public void submit(@PathVariable Long id, Authentication authentication) {
+        attenderStateService.submit(id, authentication);
     }
 }

--- a/src/main/java/kr/pullgo/pullgoserver/presentation/controller/AuthController.java
+++ b/src/main/java/kr/pullgo/pullgoserver/presentation/controller/AuthController.java
@@ -1,0 +1,34 @@
+package kr.pullgo.pullgoserver.presentation.controller;
+
+import javax.validation.Valid;
+import kr.pullgo.pullgoserver.dto.AuthDto;
+import kr.pullgo.pullgoserver.service.AuthTokenService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AuthController {
+
+    private final AuthTokenService authTokenService;
+
+    @Autowired
+    public AuthController(AuthTokenService authTokenService) {
+        this.authTokenService = authTokenService;
+    }
+
+    @PostMapping("/auth/token")
+    public AuthDto.GenerateTokenResult generateToken(
+        @Valid @RequestBody AuthDto.GenerateToken dto) {
+        return authTokenService.generateToken(dto);
+    }
+
+    @GetMapping("/auth/me")
+    public AuthDto.MeResult me(Authentication authentication) {
+        return authTokenService.getMe(authentication);
+    }
+
+}

--- a/src/main/java/kr/pullgo/pullgoserver/presentation/controller/ClassroomController.java
+++ b/src/main/java/kr/pullgo/pullgoserver/presentation/controller/ClassroomController.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -70,48 +71,49 @@ public class ClassroomController {
 
     @PostMapping("/academy/classrooms")
     @ResponseStatus(HttpStatus.CREATED)
-    public ClassroomDto.Result post(@Valid @RequestBody ClassroomDto.Create dto) {
-        return classroomService.create(dto);
+    public ClassroomDto.Result post(@Valid @RequestBody ClassroomDto.Create dto,
+        Authentication authentication) {
+        return classroomService.create(dto, authentication);
     }
 
     @PatchMapping("/academy/classrooms/{id}")
     public ClassroomDto.Result patch(@PathVariable Long id,
-        @Valid @RequestBody ClassroomDto.Update dto) {
-        return classroomService.update(id, dto);
+        @Valid @RequestBody ClassroomDto.Update dto, Authentication authentication) {
+        return classroomService.update(id, dto, authentication);
     }
 
     @DeleteMapping("/academy/classrooms/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable Long id) {
-        classroomService.delete(id);
+    public void delete(@PathVariable Long id, Authentication authentication) {
+        classroomService.delete(id, authentication);
     }
 
     @PostMapping("/academy/classrooms/{id}/accept-teacher")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void acceptTeacher(@PathVariable Long id,
-        @Valid @RequestBody ClassroomDto.AcceptTeacher dto) {
-        classroomService.acceptTeacher(id, dto);
+        @Valid @RequestBody ClassroomDto.AcceptTeacher dto, Authentication authentication) {
+        classroomService.acceptTeacher(id, dto, authentication);
     }
 
     @PostMapping("/academy/classrooms/{id}/kick-teacher")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void kickTeacher(@PathVariable Long id,
-        @Valid @RequestBody ClassroomDto.KickTeacher dto) {
-        classroomService.kickTeacher(id, dto);
+        @Valid @RequestBody ClassroomDto.KickTeacher dto, Authentication authentication) {
+        classroomService.kickTeacher(id, dto, authentication);
     }
 
 
     @PostMapping("/academy/classrooms/{id}/accept-student")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void acceptStudent(@PathVariable Long id,
-        @Valid @RequestBody ClassroomDto.AcceptStudent dto) {
-        classroomService.acceptStudent(id, dto);
+        @Valid @RequestBody ClassroomDto.AcceptStudent dto, Authentication authentication) {
+        classroomService.acceptStudent(id, dto, authentication);
     }
 
     @PostMapping("/academy/classrooms/{id}/kick-student")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void kickStudent(@PathVariable Long id,
-        @Valid @RequestBody ClassroomDto.KickStudent dto) {
-        classroomService.kickStudent(id, dto);
+        @Valid @RequestBody ClassroomDto.KickStudent dto, Authentication authentication) {
+        classroomService.kickStudent(id, dto, authentication);
     }
 }

--- a/src/main/java/kr/pullgo/pullgoserver/presentation/controller/ExamController.java
+++ b/src/main/java/kr/pullgo/pullgoserver/presentation/controller/ExamController.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -32,8 +33,9 @@ public class ExamController {
 
     @PostMapping("/exams")
     @ResponseStatus(HttpStatus.CREATED)
-    public ExamDto.Result post(@Valid @RequestBody ExamDto.Create dto) {
-        return examService.create(dto);
+    public ExamDto.Result post(@Valid @RequestBody ExamDto.Create dto,
+        Authentication authentication) {
+        return examService.create(dto, authentication);
     }
 
     @GetMapping("/exams")
@@ -64,24 +66,25 @@ public class ExamController {
 
     @DeleteMapping("/exams/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable Long id) {
-        examService.delete(id);
+    public void delete(@PathVariable Long id, Authentication authentication) {
+        examService.delete(id, authentication);
     }
 
     @PatchMapping("/exams/{id}")
-    public ExamDto.Result patch(@PathVariable Long id, @Valid @RequestBody ExamDto.Update dto) {
-        return examService.update(id, dto);
+    public ExamDto.Result patch(@PathVariable Long id, @Valid @RequestBody ExamDto.Update dto,
+        Authentication authentication) {
+        return examService.update(id, dto, authentication);
     }
 
     @PostMapping("/exams/{id}/cancel")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void cancel(@PathVariable Long id) {
-        examService.cancelExam(id);
+    public void cancel(@PathVariable Long id, Authentication authentication) {
+        examService.cancelExam(id, authentication);
     }
 
     @PostMapping("/exams/{id}/finish")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void finish(@PathVariable Long id) {
-        examService.finishExam(id);
+    public void finish(@PathVariable Long id, Authentication authentication) {
+        examService.finishExam(id, authentication);
     }
 }

--- a/src/main/java/kr/pullgo/pullgoserver/presentation/controller/LessonController.java
+++ b/src/main/java/kr/pullgo/pullgoserver/presentation/controller/LessonController.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -34,8 +35,9 @@ public class LessonController {
 
     @PostMapping("/academy/classroom/lessons")
     @ResponseStatus(HttpStatus.CREATED)
-    public LessonDto.Result post(@Valid @RequestBody LessonDto.Create dto) {
-        return lessonService.create(dto);
+    public LessonDto.Result post(@Valid @RequestBody LessonDto.Create dto,
+        Authentication authentication) {
+        return lessonService.create(dto, authentication);
     }
 
     @GetMapping("/academy/classroom/lessons")
@@ -78,13 +80,14 @@ public class LessonController {
 
     @DeleteMapping("/academy/classroom/lessons/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable Long id) {
-        lessonService.delete(id);
+    public void delete(@PathVariable Long id, Authentication authentication) {
+        lessonService.delete(id, authentication);
     }
 
     @PatchMapping("/academy/classroom/lessons/{id}")
-    public LessonDto.Result patch(@PathVariable Long id, @Valid @RequestBody LessonDto.Update dto) {
-        return lessonService.update(id, dto);
+    public LessonDto.Result patch(@PathVariable Long id, @Valid @RequestBody LessonDto.Update dto,
+        Authentication authentication) {
+        return lessonService.update(id, dto, authentication);
     }
 
 }

--- a/src/main/java/kr/pullgo/pullgoserver/presentation/controller/QuestionController.java
+++ b/src/main/java/kr/pullgo/pullgoserver/presentation/controller/QuestionController.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -32,8 +33,9 @@ public class QuestionController {
 
     @PostMapping("/exam/questions")
     @ResponseStatus(HttpStatus.CREATED)
-    public QuestionDto.Result post(@Valid @RequestBody QuestionDto.Create dto) {
-        return questionService.create(dto);
+    public QuestionDto.Result post(@Valid @RequestBody QuestionDto.Create dto,
+        Authentication authentication) {
+        return questionService.create(dto, authentication);
     }
 
     @GetMapping("/exam/questions")
@@ -56,14 +58,14 @@ public class QuestionController {
 
     @DeleteMapping("/exam/questions/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable Long id) {
-        questionService.delete(id);
+    public void delete(@PathVariable Long id, Authentication authentication) {
+        questionService.delete(id, authentication);
     }
 
     @PatchMapping("/exam/questions/{id}")
     public QuestionDto.Result patch(@PathVariable Long id,
-        @Valid @RequestBody QuestionDto.Update dto) {
-        return questionService.update(id, dto);
+        @Valid @RequestBody QuestionDto.Update dto, Authentication authentication) {
+        return questionService.update(id, dto, authentication);
     }
 
 }

--- a/src/main/java/kr/pullgo/pullgoserver/presentation/controller/StudentController.java
+++ b/src/main/java/kr/pullgo/pullgoserver/presentation/controller/StudentController.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -68,41 +69,41 @@ public class StudentController {
 
     @DeleteMapping("/students/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable Long id) {
-        studentService.delete(id);
+    public void delete(@PathVariable Long id, Authentication authentication) {
+        studentService.delete(id, authentication);
     }
 
     @PatchMapping("/students/{id}")
     public StudentDto.Result patch(@PathVariable Long id,
-        @Valid @RequestBody StudentDto.Update dto) {
-        return studentService.update(id, dto);
+        @Valid @RequestBody StudentDto.Update dto, Authentication authentication) {
+        return studentService.update(id, dto, authentication);
     }
 
     @PostMapping("/students/{id}/apply-academy")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void applyAcademy(@PathVariable Long id,
-        @Valid @RequestBody StudentDto.ApplyAcademy dto) {
-        studentService.applyAcademy(id, dto);
+        @Valid @RequestBody StudentDto.ApplyAcademy dto, Authentication authentication) {
+        studentService.applyAcademy(id, dto, authentication);
     }
 
     @PostMapping("/students/{id}/remove-applied-academy")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAppliedAcademy(@PathVariable Long id,
-        @Valid @RequestBody StudentDto.RemoveAppliedAcademy dto) {
-        studentService.removeAppliedAcademy(id, dto);
+        @Valid @RequestBody StudentDto.RemoveAppliedAcademy dto, Authentication authentication) {
+        studentService.removeAppliedAcademy(id, dto, authentication);
     }
 
     @PostMapping("/students/{id}/apply-classroom")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void applyClassroom(@PathVariable Long id,
-        @Valid @RequestBody StudentDto.ApplyClassroom dto) {
-        studentService.applyClassroom(id, dto);
+        @Valid @RequestBody StudentDto.ApplyClassroom dto, Authentication authentication) {
+        studentService.applyClassroom(id, dto, authentication);
     }
 
     @PostMapping("/students/{id}/remove-applied-classroom")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAppliedClassroom(@PathVariable Long id,
-        @Valid @RequestBody StudentDto.RemoveAppliedClassroom dto) {
-        studentService.removeAppliedClassroom(id, dto);
+        @Valid @RequestBody StudentDto.RemoveAppliedClassroom dto, Authentication authentication) {
+        studentService.removeAppliedClassroom(id, dto, authentication);
     }
 }

--- a/src/main/java/kr/pullgo/pullgoserver/presentation/controller/TeacherController.java
+++ b/src/main/java/kr/pullgo/pullgoserver/presentation/controller/TeacherController.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -68,41 +69,41 @@ public class TeacherController {
 
     @DeleteMapping("/teachers/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable Long id) {
-        teacherService.delete(id);
+    public void delete(@PathVariable Long id, Authentication authentication) {
+        teacherService.delete(id, authentication);
     }
 
     @PatchMapping("/teachers/{id}")
     public TeacherDto.Result patch(@PathVariable Long id,
-        @Valid @RequestBody TeacherDto.Update dto) {
-        return teacherService.update(id, dto);
+        @Valid @RequestBody TeacherDto.Update dto, Authentication authentication) {
+        return teacherService.update(id, dto, authentication);
     }
 
     @PostMapping("/teachers/{id}/apply-academy")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void applyAcademy(@PathVariable Long id,
-        @Valid @RequestBody TeacherDto.ApplyAcademy dto) {
-        teacherService.applyAcademy(id, dto);
+        @Valid @RequestBody TeacherDto.ApplyAcademy dto, Authentication authentication) {
+        teacherService.applyAcademy(id, dto, authentication);
     }
 
     @PostMapping("/teachers/{id}/remove-applied-academy")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAppliedAcademy(@PathVariable Long id,
-        @Valid @RequestBody TeacherDto.RemoveAppliedAcademy dto) {
-        teacherService.removeAppliedAcademy(id, dto);
+        @Valid @RequestBody TeacherDto.RemoveAppliedAcademy dto, Authentication authentication) {
+        teacherService.removeAppliedAcademy(id, dto, authentication);
     }
 
     @PostMapping("/teachers/{id}/apply-classroom")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void applyClassroom(@PathVariable Long id,
-        @Valid @RequestBody TeacherDto.ApplyClassroom dto) {
-        teacherService.applyClassroom(id, dto);
+        @Valid @RequestBody TeacherDto.ApplyClassroom dto, Authentication authentication) {
+        teacherService.applyClassroom(id, dto, authentication);
     }
 
     @PostMapping("/teachers/{id}/remove-applied-classroom")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void removeAppliedClassroom(@PathVariable Long id,
-        @Valid @RequestBody TeacherDto.RemoveAppliedClassroom dto) {
-        teacherService.removeAppliedClassroom(id, dto);
+        @Valid @RequestBody TeacherDto.RemoveAppliedClassroom dto, Authentication authentication) {
+        teacherService.removeAppliedClassroom(id, dto, authentication);
     }
 }

--- a/src/main/java/kr/pullgo/pullgoserver/service/AccountService.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/AccountService.java
@@ -5,20 +5,26 @@ import kr.pullgo.pullgoserver.dto.mapper.AccountDtoMapper;
 import kr.pullgo.pullgoserver.persistence.model.Account;
 import kr.pullgo.pullgoserver.persistence.model.UserRole;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 public class AccountService {
 
     private final AccountDtoMapper dtoMapper;
+    private final PasswordEncoder passwordEncoder;
 
     @Autowired
-    public AccountService(AccountDtoMapper dtoMapper) {
+    public AccountService(AccountDtoMapper dtoMapper, PasswordEncoder passwordEncoder) {
         this.dtoMapper = dtoMapper;
+        this.passwordEncoder = passwordEncoder;
     }
 
     public Account create(AccountDto.Create dto) {
         Account entity = dtoMapper.asEntity(dto);
+
+        String encodedPassword = passwordEncoder.encode(dto.getPassword());
+        entity.setPassword(encodedPassword);
 
         entity.setRole(UserRole.USER);
 
@@ -27,7 +33,8 @@ public class AccountService {
 
     public void update(Account entity, AccountDto.Update dto) {
         if (dto.getPassword() != null) {
-            entity.setPassword(dto.getPassword());
+            String encodedPassword = passwordEncoder.encode(dto.getPassword());
+            entity.setPassword(encodedPassword);
         }
         if (dto.getFullName() != null) {
             entity.setFullName(dto.getFullName());

--- a/src/main/java/kr/pullgo/pullgoserver/service/AccountService.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/AccountService.java
@@ -1,11 +1,29 @@
 package kr.pullgo.pullgoserver.service;
 
 import kr.pullgo.pullgoserver.dto.AccountDto;
+import kr.pullgo.pullgoserver.dto.mapper.AccountDtoMapper;
 import kr.pullgo.pullgoserver.persistence.model.Account;
+import kr.pullgo.pullgoserver.persistence.model.UserRole;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class AccountService {
+
+    private final AccountDtoMapper dtoMapper;
+
+    @Autowired
+    public AccountService(AccountDtoMapper dtoMapper) {
+        this.dtoMapper = dtoMapper;
+    }
+
+    public Account create(AccountDto.Create dto) {
+        Account entity = dtoMapper.asEntity(dto);
+
+        entity.setRole(UserRole.USER);
+
+        return entity;
+    }
 
     public void update(Account entity, AccountDto.Update dto) {
         if (dto.getPassword() != null) {

--- a/src/main/java/kr/pullgo/pullgoserver/service/AttenderAnswerService.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/AttenderAnswerService.java
@@ -8,11 +8,13 @@ import kr.pullgo.pullgoserver.persistence.model.AttenderAnswer;
 import kr.pullgo.pullgoserver.persistence.model.AttenderState;
 import kr.pullgo.pullgoserver.persistence.model.Question;
 import kr.pullgo.pullgoserver.persistence.repository.AttenderAnswerRepository;
+import kr.pullgo.pullgoserver.service.authorizer.AttenderAnswerAuthorizer;
 import kr.pullgo.pullgoserver.service.helper.RepositoryHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,24 +24,30 @@ public class AttenderAnswerService {
     private final AttenderAnswerDtoMapper dtoMapper;
     private final AttenderAnswerRepository attenderAnswerRepository;
     private final RepositoryHelper repoHelper;
+    private final AttenderAnswerAuthorizer attenderAnswerAuthorizer;
 
     @Autowired
     public AttenderAnswerService(AttenderAnswerDtoMapper dtoMapper,
         AttenderAnswerRepository attenderAnswerRepository,
-        RepositoryHelper repoHelper) {
+        RepositoryHelper repoHelper,
+        AttenderAnswerAuthorizer attenderAnswerAuthorizer) {
         this.dtoMapper = dtoMapper;
         this.attenderAnswerRepository = attenderAnswerRepository;
         this.repoHelper = repoHelper;
+        this.attenderAnswerAuthorizer = attenderAnswerAuthorizer;
     }
 
     @Transactional
-    public AttenderAnswerDto.Result create(AttenderAnswerDto.Create dto) {
+    public AttenderAnswerDto.Result create(AttenderAnswerDto.Create dto,
+        Authentication authentication) {
+        AttenderState attenderState = repoHelper.findAttenderStateOrThrow(dto.getAttenderStateId());
+        attenderAnswerAuthorizer.requireByOneself(authentication, attenderState.getAttender());
+
         AttenderAnswer attenderAnswer = dtoMapper.asEntity(dto);
 
         Question question = repoHelper.findQuestionOrThrow(dto.getQuestionId());
         attenderAnswer.setQuestion(question);
 
-        AttenderState attenderState = repoHelper.findAttenderStateOrThrow(dto.getAttenderStateId());
         attenderState.addAnswer(attenderAnswer);
 
         return dtoMapper.asResultDto(attenderAnswerRepository.save(attenderAnswer));
@@ -59,8 +67,11 @@ public class AttenderAnswerService {
     }
 
     @Transactional
-    public AttenderAnswerDto.Result update(Long id, AttenderAnswerDto.Update dto) {
+    public AttenderAnswerDto.Result update(Long id, AttenderAnswerDto.Update dto,
+        Authentication authentication) {
         AttenderAnswer entity = repoHelper.findAttenderAnswerOrThrow(id);
+        attenderAnswerAuthorizer.requireOwningAttender(authentication, entity);
+
         if (dto.getAnswer() != null) {
             entity.setAnswer(new Answer(dto.getAnswer()));
         }
@@ -68,8 +79,10 @@ public class AttenderAnswerService {
     }
 
     @Transactional
-    public void delete(Long id) {
+    public void delete(Long id, Authentication authentication) {
         AttenderAnswer entity = repoHelper.findAttenderAnswerOrThrow(id);
+        attenderAnswerAuthorizer.requireOwningAttender(authentication, entity);
+
         attenderAnswerRepository.delete(entity);
     }
 }

--- a/src/main/java/kr/pullgo/pullgoserver/service/AuthTokenService.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/AuthTokenService.java
@@ -1,0 +1,100 @@
+package kr.pullgo.pullgoserver.service;
+
+import kr.pullgo.pullgoserver.config.security.UserPrincipal;
+import kr.pullgo.pullgoserver.dto.AuthDto;
+import kr.pullgo.pullgoserver.dto.StudentDto;
+import kr.pullgo.pullgoserver.dto.TeacherDto;
+import kr.pullgo.pullgoserver.dto.mapper.StudentDtoMapper;
+import kr.pullgo.pullgoserver.dto.mapper.TeacherDtoMapper;
+import kr.pullgo.pullgoserver.persistence.model.Account;
+import kr.pullgo.pullgoserver.persistence.model.Student;
+import kr.pullgo.pullgoserver.persistence.model.Teacher;
+import kr.pullgo.pullgoserver.persistence.repository.AccountRepository;
+import kr.pullgo.pullgoserver.persistence.repository.StudentRepository;
+import kr.pullgo.pullgoserver.persistence.repository.TeacherRepository;
+import kr.pullgo.pullgoserver.service.helper.ServiceErrorHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthTokenService {
+
+    private final JwtService jwtService;
+    private final PasswordEncoder passwordEncoder;
+    private final AccountRepository accountRepository;
+    private final StudentRepository studentRepository;
+    private final StudentDtoMapper studentDtoMapper;
+    private final TeacherRepository teacherRepository;
+    private final TeacherDtoMapper teacherDtoMapper;
+    private final ServiceErrorHelper errorHelper;
+
+    @Autowired
+    public AuthTokenService(JwtService jwtService,
+        PasswordEncoder passwordEncoder,
+        AccountRepository accountRepository,
+        StudentRepository studentRepository,
+        StudentDtoMapper studentDtoMapper,
+        TeacherRepository teacherRepository,
+        TeacherDtoMapper teacherDtoMapper,
+        ServiceErrorHelper errorHelper) {
+        this.jwtService = jwtService;
+        this.passwordEncoder = passwordEncoder;
+        this.accountRepository = accountRepository;
+        this.studentRepository = studentRepository;
+        this.studentDtoMapper = studentDtoMapper;
+        this.teacherRepository = teacherRepository;
+        this.teacherDtoMapper = teacherDtoMapper;
+        this.errorHelper = errorHelper;
+    }
+
+    public AuthDto.GenerateTokenResult generateToken(AuthDto.GenerateToken dto) {
+        Account account = accountRepository.findByUsername(dto.getUsername())
+            .orElseThrow(() -> errorHelper.unauthorized("Username not found"));
+
+        if (!passwordEncoder.matches(dto.getPassword(), account.getPassword())) {
+            throw errorHelper.unauthorized("Wrong password");
+        }
+
+        String token = jwtService.signJwt(account);
+
+        return AuthDto.GenerateTokenResult.builder()
+            .token(token)
+            .student(getStudentDtoIfExists(account.getId()))
+            .teacher(getTeacherDtoIfExists(account.getId()))
+            .build();
+    }
+
+    public AuthDto.MeResult getMe(Authentication authentication) {
+        if (authentication == null)
+            throw errorHelper.unauthorized("Not authenticated");
+
+        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+
+        Account account = accountRepository.findById(principal.getAccountId())
+            .orElseThrow(() -> errorHelper.unauthorized("Removed account"));
+
+        return AuthDto.MeResult.builder()
+            .student(getStudentDtoIfExists(account.getId()))
+            .teacher(getTeacherDtoIfExists(account.getId()))
+            .build();
+    }
+
+    private StudentDto.Result getStudentDtoIfExists(Long accountId) {
+        Student student = studentRepository.findByAccountId(accountId);
+        if (student != null) {
+            return studentDtoMapper.asResultDto(student);
+        }
+        return null;
+    }
+
+    private TeacherDto.Result getTeacherDtoIfExists(Long accountId) {
+        Teacher teacher = teacherRepository.findByAccountId(accountId);
+        if (teacher != null) {
+            return teacherDtoMapper.asResultDto(teacher);
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/kr/pullgo/pullgoserver/service/JwtService.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/JwtService.java
@@ -1,0 +1,76 @@
+package kr.pullgo.pullgoserver.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import java.time.Instant;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import kr.pullgo.pullgoserver.config.security.UserPrincipal;
+import kr.pullgo.pullgoserver.persistence.model.Account;
+import lombok.SneakyThrows;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JwtService {
+
+    public static final String JWT_ISSUER = "pullgo-server";
+    private final ObjectMapper objectMapper;
+    private final SecretKey signingKey;
+    private final int expirationInterval;
+    private final JwtParser jwtParser;
+
+    @Autowired
+    public JwtService(ObjectMapper objectMapper,
+        @Value("${auth.jwt.key.secret-string}") String secretString,
+        @Value("${auth.jwt.expiration-interval}") int expirationInterval) {
+        this.objectMapper = objectMapper;
+        this.signingKey = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(secretString));
+        this.expirationInterval = expirationInterval;
+        this.jwtParser = Jwts.parserBuilder()
+            .setSigningKey(signingKey)
+            .build();
+    }
+
+    @SneakyThrows
+    public String signJwt(Account account) {
+        UserPrincipal principal = UserPrincipal.builder()
+            .accountId(account.getId())
+            .username(account.getUsername())
+            .build();
+
+        String subject = objectMapper.writeValueAsString(principal);
+
+        Instant now = Instant.now();
+        Date nowDate = Date.from(now);
+        Date expDate = Date.from(now.plusSeconds(expirationInterval));
+
+        return Jwts.builder()
+            .setIssuer(JWT_ISSUER)
+            .setSubject(subject)
+            .setExpiration(expDate)
+            .setIssuedAt(nowDate)
+            .signWith(signingKey, SignatureAlgorithm.HS256)
+            .compact();
+    }
+
+    @SneakyThrows
+    public UserPrincipal extractSubject(String jwt)
+        throws ExpiredJwtException, UnsupportedJwtException,
+        MalformedJwtException, SignatureException {
+        String subject = jwtParser.parseClaimsJws(jwt)
+            .getBody()
+            .getSubject();
+        return objectMapper.readValue(subject, UserPrincipal.class);
+    }
+
+}

--- a/src/main/java/kr/pullgo/pullgoserver/service/QuestionService.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/QuestionService.java
@@ -7,11 +7,13 @@ import kr.pullgo.pullgoserver.persistence.model.Answer;
 import kr.pullgo.pullgoserver.persistence.model.Exam;
 import kr.pullgo.pullgoserver.persistence.model.Question;
 import kr.pullgo.pullgoserver.persistence.repository.QuestionRepository;
+import kr.pullgo.pullgoserver.service.authorizer.QuestionAuthorizer;
 import kr.pullgo.pullgoserver.service.helper.RepositoryHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,23 +23,28 @@ public class QuestionService {
     private final QuestionDtoMapper dtoMapper;
     private final QuestionRepository questionRepository;
     private final RepositoryHelper repoHelper;
+    private final QuestionAuthorizer questionAuthorizer;
 
     @Autowired
     public QuestionService(
         QuestionDtoMapper dtoMapper,
         QuestionRepository questionRepository,
-        RepositoryHelper repoHelper) {
+        RepositoryHelper repoHelper,
+        QuestionAuthorizer questionAuthorizer) {
         this.dtoMapper = dtoMapper;
         this.questionRepository = questionRepository;
         this.repoHelper = repoHelper;
+        this.questionAuthorizer = questionAuthorizer;
     }
 
     @Transactional
-    public QuestionDto.Result create(QuestionDto.Create dto) {
+    public QuestionDto.Result create(QuestionDto.Create dto, Authentication authentication) {
         Question question = dtoMapper.asEntity(dto);
 
         Exam exam = repoHelper.findExamOrThrow(dto.getExamId());
         exam.addQuestion(question);
+
+        questionAuthorizer.requireExamCreator(authentication, question);
 
         return dtoMapper.asResultDto(questionRepository.save(question));
     }
@@ -55,8 +62,11 @@ public class QuestionService {
     }
 
     @Transactional
-    public QuestionDto.Result update(Long id, QuestionDto.Update dto) {
+    public QuestionDto.Result update(Long id, QuestionDto.Update dto,
+        Authentication authentication) {
         Question entity = repoHelper.findQuestionOrThrow(id);
+        questionAuthorizer.requireExamCreator(authentication, entity);
+
         if (dto.getContent() != null) {
             entity.setContent(dto.getContent());
         }
@@ -70,8 +80,9 @@ public class QuestionService {
     }
 
     @Transactional
-    public void delete(Long id) {
+    public void delete(Long id, Authentication authentication) {
         Question entity = repoHelper.findQuestionOrThrow(id);
+        questionAuthorizer.requireExamCreator(authentication, entity);
         questionRepository.delete(entity);
     }
 }

--- a/src/main/java/kr/pullgo/pullgoserver/service/StudentService.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/StudentService.java
@@ -51,7 +51,11 @@ public class StudentService {
 
     @Transactional
     public StudentDto.Result create(StudentDto.Create dto) {
-        return dtoMapper.asResultDto(studentRepository.save(dtoMapper.asEntity(dto)));
+        Student student = studentRepository.save(dtoMapper.asEntity(dto));
+
+        student.setAccount(accountService.create(dto.getAccount()));
+
+        return dtoMapper.asResultDto(student);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/kr/pullgo/pullgoserver/service/TeacherService.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/TeacherService.java
@@ -51,7 +51,11 @@ public class TeacherService {
 
     @Transactional
     public TeacherDto.Result create(TeacherDto.Create dto) {
-        return dtoMapper.asResultDto(teacherRepository.save(dtoMapper.asEntity(dto)));
+        Teacher teacher = teacherRepository.save(dtoMapper.asEntity(dto));
+
+        teacher.setAccount(accountService.create(dto.getAccount()));
+
+        return dtoMapper.asResultDto(teacher);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/kr/pullgo/pullgoserver/service/authorizer/AbstractAuthorizer.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/authorizer/AbstractAuthorizer.java
@@ -1,0 +1,77 @@
+package kr.pullgo.pullgoserver.service.authorizer;
+
+import kr.pullgo.pullgoserver.persistence.model.Account;
+import kr.pullgo.pullgoserver.persistence.model.Student;
+import kr.pullgo.pullgoserver.persistence.model.Teacher;
+import kr.pullgo.pullgoserver.persistence.repository.StudentRepository;
+import kr.pullgo.pullgoserver.persistence.repository.TeacherRepository;
+import kr.pullgo.pullgoserver.service.helper.ServiceErrorHelper;
+import org.springframework.security.core.Authentication;
+
+public class AbstractAuthorizer {
+
+    private final AuthenticationInspector authInspector;
+    private final StudentRepository studentRepository;
+    private final TeacherRepository teacherRepository;
+    private final ServiceErrorHelper errorHelper;
+
+    public AbstractAuthorizer(
+        AuthenticationInspector authInspector,
+        StudentRepository studentRepository,
+        TeacherRepository teacherRepository,
+        ServiceErrorHelper errorHelper) {
+        this.authInspector = authInspector;
+        this.studentRepository = studentRepository;
+        this.teacherRepository = teacherRepository;
+        this.errorHelper = errorHelper;
+    }
+
+    public void requireByOneself(Authentication authentication, Student requester) {
+        if (authInspector.isAdmin(authentication))
+            return;
+        Account account = authInspector.getAccountOrThrow(authentication);
+
+        Student student = getStudentOrThrow(account);
+        if (student != requester) {
+            throw errorHelper.forbidden("Not requested oneself");
+        }
+    }
+
+    public void requireByOneself(Authentication authentication, Teacher requester) {
+        if (authInspector.isAdmin(authentication))
+            return;
+        Account account = authInspector.getAccountOrThrow(authentication);
+
+        Teacher teacher = getTeacherOrThrow(account);
+        if (teacher != requester) {
+            throw errorHelper.forbidden("Not requested oneself");
+        }
+    }
+
+    protected Student getStudentOrThrow(Account account) {
+        Student student = studentRepository.findByAccountId(account.getId());
+        if (student == null) {
+            throw errorHelper.forbidden("Not a student");
+        }
+        return student;
+    }
+
+    protected boolean isStudent(Account account) {
+        Student student = studentRepository.findByAccountId(account.getId());
+        return student != null;
+    }
+
+    protected Teacher getTeacherOrThrow(Account account) {
+        Teacher teacher = teacherRepository.findByAccountId(account.getId());
+        if (teacher == null) {
+            throw errorHelper.forbidden("Not a teacher");
+        }
+        return teacher;
+    }
+
+    protected boolean isTeacher(Account account) {
+        Teacher teacher = teacherRepository.findByAccountId(account.getId());
+        return teacher != null;
+    }
+
+}

--- a/src/main/java/kr/pullgo/pullgoserver/service/authorizer/AcademyAuthorizer.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/authorizer/AcademyAuthorizer.java
@@ -1,0 +1,51 @@
+package kr.pullgo.pullgoserver.service.authorizer;
+
+import kr.pullgo.pullgoserver.persistence.model.Academy;
+import kr.pullgo.pullgoserver.persistence.model.Account;
+import kr.pullgo.pullgoserver.persistence.model.Teacher;
+import kr.pullgo.pullgoserver.persistence.repository.StudentRepository;
+import kr.pullgo.pullgoserver.persistence.repository.TeacherRepository;
+import kr.pullgo.pullgoserver.service.helper.ServiceErrorHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AcademyAuthorizer extends AbstractAuthorizer {
+
+    private final AuthenticationInspector authInspector;
+    private final ServiceErrorHelper errorHelper;
+
+    @Autowired
+    public AcademyAuthorizer(
+        AuthenticationInspector authInspector,
+        StudentRepository studentRepository,
+        TeacherRepository teacherRepository,
+        ServiceErrorHelper errorHelper) {
+        super(authInspector, studentRepository, teacherRepository, errorHelper);
+        this.authInspector = authInspector;
+        this.errorHelper = errorHelper;
+    }
+
+    public void requireOwner(Authentication authentication, Academy academy) {
+        if (authInspector.isAdmin(authentication))
+            return;
+        Account account = authInspector.getAccountOrThrow(authentication);
+
+        Teacher teacher = getTeacherOrThrow(account);
+        if (teacher != academy.getOwner()) {
+            throw errorHelper.forbidden("Not the owner");
+        }
+    }
+
+    public void requireMemberTeacher(Authentication authentication, Academy academy) {
+        if (authInspector.isAdmin(authentication))
+            return;
+        Account account = authInspector.getAccountOrThrow(authentication);
+
+        Teacher teacher = getTeacherOrThrow(account);
+        if (!academy.getTeachers().contains(teacher)) {
+            throw errorHelper.forbidden("Not a member teacher");
+        }
+    }
+}

--- a/src/main/java/kr/pullgo/pullgoserver/service/authorizer/AttenderAnswerAuthorizer.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/authorizer/AttenderAnswerAuthorizer.java
@@ -1,0 +1,41 @@
+package kr.pullgo.pullgoserver.service.authorizer;
+
+import kr.pullgo.pullgoserver.persistence.model.Account;
+import kr.pullgo.pullgoserver.persistence.model.AttenderAnswer;
+import kr.pullgo.pullgoserver.persistence.model.Student;
+import kr.pullgo.pullgoserver.persistence.repository.StudentRepository;
+import kr.pullgo.pullgoserver.persistence.repository.TeacherRepository;
+import kr.pullgo.pullgoserver.service.helper.ServiceErrorHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AttenderAnswerAuthorizer extends AbstractAuthorizer {
+
+    private final AuthenticationInspector authInspector;
+    private final ServiceErrorHelper errorHelper;
+
+    @Autowired
+    public AttenderAnswerAuthorizer(
+        AuthenticationInspector authInspector,
+        StudentRepository studentRepository,
+        TeacherRepository teacherRepository,
+        ServiceErrorHelper errorHelper) {
+        super(authInspector, studentRepository, teacherRepository, errorHelper);
+        this.authInspector = authInspector;
+        this.errorHelper = errorHelper;
+    }
+
+    public void requireOwningAttender(Authentication authentication,
+        AttenderAnswer attenderAnswer) {
+        if (authInspector.isAdmin(authentication))
+            return;
+        Account account = authInspector.getAccountOrThrow(authentication);
+
+        Student student = getStudentOrThrow(account);
+        if (student != attenderAnswer.getAttenderState().getAttender()) {
+            throw errorHelper.forbidden("Not the owning attender");
+        }
+    }
+}

--- a/src/main/java/kr/pullgo/pullgoserver/service/authorizer/AttenderStateAuthorizer.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/authorizer/AttenderStateAuthorizer.java
@@ -1,0 +1,41 @@
+package kr.pullgo.pullgoserver.service.authorizer;
+
+import kr.pullgo.pullgoserver.persistence.model.Account;
+import kr.pullgo.pullgoserver.persistence.model.AttenderState;
+import kr.pullgo.pullgoserver.persistence.model.Student;
+import kr.pullgo.pullgoserver.persistence.repository.StudentRepository;
+import kr.pullgo.pullgoserver.persistence.repository.TeacherRepository;
+import kr.pullgo.pullgoserver.service.helper.ServiceErrorHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AttenderStateAuthorizer extends AbstractAuthorizer {
+
+    private final AuthenticationInspector authInspector;
+    private final ServiceErrorHelper errorHelper;
+
+    @Autowired
+    public AttenderStateAuthorizer(
+        AuthenticationInspector authInspector,
+        StudentRepository studentRepository,
+        TeacherRepository teacherRepository,
+        ServiceErrorHelper errorHelper) {
+        super(authInspector, studentRepository, teacherRepository, errorHelper);
+        this.authInspector = authInspector;
+        this.errorHelper = errorHelper;
+    }
+
+    public void requireOwningAttender(Authentication authentication, AttenderState attenderState) {
+        if (authInspector.isAdmin(authentication))
+            return;
+        Account account = authInspector.getAccountOrThrow(authentication);
+
+        Student student = getStudentOrThrow(account);
+        if (student != attenderState.getAttender()) {
+            throw errorHelper.forbidden("Not the owning attender");
+        }
+    }
+
+}

--- a/src/main/java/kr/pullgo/pullgoserver/service/authorizer/AuthenticationInspector.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/authorizer/AuthenticationInspector.java
@@ -1,0 +1,41 @@
+package kr.pullgo.pullgoserver.service.authorizer;
+
+import kr.pullgo.pullgoserver.config.security.UserPrincipal;
+import kr.pullgo.pullgoserver.persistence.model.Account;
+import kr.pullgo.pullgoserver.persistence.repository.AccountRepository;
+import kr.pullgo.pullgoserver.service.helper.ServiceErrorHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthenticationInspector {
+
+    private final AccountRepository accountRepository;
+    private final ServiceErrorHelper errorHelper;
+
+    @Autowired
+    public AuthenticationInspector(
+        AccountRepository accountRepository,
+        ServiceErrorHelper errorHelper) {
+        this.accountRepository = accountRepository;
+        this.errorHelper = errorHelper;
+    }
+
+    public Account getAccountOrThrow(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw errorHelper.unauthorized("Not authenticated");
+        }
+
+        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+
+        return accountRepository.findById(principal.getAccountId())
+            .orElseThrow(() -> errorHelper.forbidden("Removed account"));
+    }
+
+    public boolean isAdmin(Authentication authentication) {
+        return authentication.getAuthorities().stream()
+            .anyMatch(authority -> authority.getAuthority().equals("ADMIN"));
+    }
+
+}

--- a/src/main/java/kr/pullgo/pullgoserver/service/authorizer/ClassroomAuthorizer.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/authorizer/ClassroomAuthorizer.java
@@ -1,0 +1,41 @@
+package kr.pullgo.pullgoserver.service.authorizer;
+
+import kr.pullgo.pullgoserver.persistence.model.Account;
+import kr.pullgo.pullgoserver.persistence.model.Classroom;
+import kr.pullgo.pullgoserver.persistence.model.Teacher;
+import kr.pullgo.pullgoserver.persistence.repository.StudentRepository;
+import kr.pullgo.pullgoserver.persistence.repository.TeacherRepository;
+import kr.pullgo.pullgoserver.service.helper.ServiceErrorHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ClassroomAuthorizer extends AbstractAuthorizer {
+
+    private final AuthenticationInspector authInspector;
+    private final ServiceErrorHelper errorHelper;
+
+    @Autowired
+    public ClassroomAuthorizer(
+        AuthenticationInspector authInspector,
+        StudentRepository studentRepository,
+        TeacherRepository teacherRepository,
+        ServiceErrorHelper errorHelper) {
+        super(authInspector, studentRepository, teacherRepository, errorHelper);
+        this.authInspector = authInspector;
+        this.errorHelper = errorHelper;
+    }
+
+    public void requireMemberTeacher(Authentication authentication, Classroom classroom) {
+        if (authInspector.isAdmin(authentication))
+            return;
+        Account account = authInspector.getAccountOrThrow(authentication);
+
+        Teacher teacher = getTeacherOrThrow(account);
+        if (!classroom.getTeachers().contains(teacher)) {
+            throw errorHelper.forbidden("Not a member teacher");
+        }
+    }
+
+}

--- a/src/main/java/kr/pullgo/pullgoserver/service/authorizer/ExamAuthorizer.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/authorizer/ExamAuthorizer.java
@@ -1,0 +1,41 @@
+package kr.pullgo.pullgoserver.service.authorizer;
+
+import kr.pullgo.pullgoserver.persistence.model.Account;
+import kr.pullgo.pullgoserver.persistence.model.Exam;
+import kr.pullgo.pullgoserver.persistence.model.Teacher;
+import kr.pullgo.pullgoserver.persistence.repository.StudentRepository;
+import kr.pullgo.pullgoserver.persistence.repository.TeacherRepository;
+import kr.pullgo.pullgoserver.service.helper.ServiceErrorHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExamAuthorizer extends AbstractAuthorizer {
+
+    private final AuthenticationInspector authInspector;
+    private final ServiceErrorHelper errorHelper;
+
+    @Autowired
+    public ExamAuthorizer(
+        AuthenticationInspector authInspector,
+        StudentRepository studentRepository,
+        TeacherRepository teacherRepository,
+        ServiceErrorHelper errorHelper) {
+        super(authInspector, studentRepository, teacherRepository, errorHelper);
+        this.authInspector = authInspector;
+        this.errorHelper = errorHelper;
+    }
+
+    public void requireCreator(Authentication authentication, Exam exam) {
+        if (authInspector.isAdmin(authentication))
+            return;
+        Account account = authInspector.getAccountOrThrow(authentication);
+
+        Teacher teacher = getTeacherOrThrow(account);
+        if (teacher != exam.getCreator()) {
+            throw errorHelper.forbidden("Not the creator");
+        }
+    }
+
+}

--- a/src/main/java/kr/pullgo/pullgoserver/service/authorizer/LessonAuthorizer.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/authorizer/LessonAuthorizer.java
@@ -1,0 +1,41 @@
+package kr.pullgo.pullgoserver.service.authorizer;
+
+import kr.pullgo.pullgoserver.persistence.model.Account;
+import kr.pullgo.pullgoserver.persistence.model.Lesson;
+import kr.pullgo.pullgoserver.persistence.model.Teacher;
+import kr.pullgo.pullgoserver.persistence.repository.StudentRepository;
+import kr.pullgo.pullgoserver.persistence.repository.TeacherRepository;
+import kr.pullgo.pullgoserver.service.helper.ServiceErrorHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LessonAuthorizer extends AbstractAuthorizer {
+
+    private final AuthenticationInspector authInspector;
+    private final ServiceErrorHelper errorHelper;
+
+    @Autowired
+    public LessonAuthorizer(
+        AuthenticationInspector authInspector,
+        StudentRepository studentRepository,
+        TeacherRepository teacherRepository,
+        ServiceErrorHelper errorHelper) {
+        super(authInspector, studentRepository, teacherRepository, errorHelper);
+        this.authInspector = authInspector;
+        this.errorHelper = errorHelper;
+    }
+
+    public void requireClassroomTeacher(Authentication authentication, Lesson lesson) {
+        if (authInspector.isAdmin(authentication))
+            return;
+        Account account = authInspector.getAccountOrThrow(authentication);
+
+        Teacher teacher = getTeacherOrThrow(account);
+        if (!lesson.getClassroom().getTeachers().contains(teacher)) {
+            throw errorHelper.forbidden("Not a member teacher of the classroom");
+        }
+    }
+
+}

--- a/src/main/java/kr/pullgo/pullgoserver/service/authorizer/QuestionAuthorizer.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/authorizer/QuestionAuthorizer.java
@@ -1,0 +1,41 @@
+package kr.pullgo.pullgoserver.service.authorizer;
+
+import kr.pullgo.pullgoserver.persistence.model.Account;
+import kr.pullgo.pullgoserver.persistence.model.Question;
+import kr.pullgo.pullgoserver.persistence.model.Teacher;
+import kr.pullgo.pullgoserver.persistence.repository.StudentRepository;
+import kr.pullgo.pullgoserver.persistence.repository.TeacherRepository;
+import kr.pullgo.pullgoserver.service.helper.ServiceErrorHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QuestionAuthorizer extends AbstractAuthorizer {
+
+    private final AuthenticationInspector authInspector;
+    private final ServiceErrorHelper errorHelper;
+
+    @Autowired
+    public QuestionAuthorizer(
+        AuthenticationInspector authInspector,
+        StudentRepository studentRepository,
+        TeacherRepository teacherRepository,
+        ServiceErrorHelper errorHelper) {
+        super(authInspector, studentRepository, teacherRepository, errorHelper);
+        this.authInspector = authInspector;
+        this.errorHelper = errorHelper;
+    }
+
+    public void requireExamCreator(Authentication authentication, Question question) {
+        if (authInspector.isAdmin(authentication))
+            return;
+        Account account = authInspector.getAccountOrThrow(authentication);
+
+        Teacher teacher = getTeacherOrThrow(account);
+        if (teacher != question.getExam().getCreator()) {
+            throw errorHelper.forbidden("Not the creator of the exam");
+        }
+    }
+
+}

--- a/src/main/java/kr/pullgo/pullgoserver/service/authorizer/StudentAuthorizer.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/authorizer/StudentAuthorizer.java
@@ -1,0 +1,64 @@
+package kr.pullgo.pullgoserver.service.authorizer;
+
+import kr.pullgo.pullgoserver.persistence.model.Academy;
+import kr.pullgo.pullgoserver.persistence.model.Account;
+import kr.pullgo.pullgoserver.persistence.model.Classroom;
+import kr.pullgo.pullgoserver.persistence.model.Student;
+import kr.pullgo.pullgoserver.persistence.model.Teacher;
+import kr.pullgo.pullgoserver.persistence.repository.StudentRepository;
+import kr.pullgo.pullgoserver.persistence.repository.TeacherRepository;
+import kr.pullgo.pullgoserver.service.helper.ServiceErrorHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StudentAuthorizer extends AbstractAuthorizer {
+
+    private final AuthenticationInspector authInspector;
+    private final ServiceErrorHelper errorHelper;
+
+    @Autowired
+    public StudentAuthorizer(
+        AuthenticationInspector authInspector,
+        StudentRepository studentRepository,
+        TeacherRepository teacherRepository,
+        ServiceErrorHelper errorHelper) {
+        super(authInspector, studentRepository, teacherRepository, errorHelper);
+        this.authInspector = authInspector;
+        this.errorHelper = errorHelper;
+    }
+
+    public void requireByOneselfOrMemberTeacher(Authentication authentication, Student student,
+        Academy academy) {
+        if (authInspector.isAdmin(authentication))
+            return;
+        Account account = authInspector.getAccountOrThrow(authentication);
+
+        if (isStudent(account)) {
+            requireByOneself(authentication, student);
+        } else {
+            Teacher teacher = getTeacherOrThrow(account);
+            if (!academy.getTeachers().contains(teacher)) {
+                throw errorHelper.forbidden("Not a member teacher");
+            }
+        }
+    }
+
+    public void requireByOneselfOrMemberTeacher(Authentication authentication, Student student,
+        Classroom classroom) {
+        if (authInspector.isAdmin(authentication))
+            return;
+        Account account = authInspector.getAccountOrThrow(authentication);
+
+        if (isStudent(account)) {
+            requireByOneself(authentication, student);
+        } else {
+            Teacher teacher = getTeacherOrThrow(account);
+            if (!classroom.getTeachers().contains(teacher)) {
+                throw errorHelper.forbidden("Not a member teacher");
+            }
+        }
+    }
+
+}

--- a/src/main/java/kr/pullgo/pullgoserver/service/authorizer/TeacherAuthorizer.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/authorizer/TeacherAuthorizer.java
@@ -1,0 +1,55 @@
+package kr.pullgo.pullgoserver.service.authorizer;
+
+import kr.pullgo.pullgoserver.persistence.model.Academy;
+import kr.pullgo.pullgoserver.persistence.model.Account;
+import kr.pullgo.pullgoserver.persistence.model.Classroom;
+import kr.pullgo.pullgoserver.persistence.model.Teacher;
+import kr.pullgo.pullgoserver.persistence.repository.StudentRepository;
+import kr.pullgo.pullgoserver.persistence.repository.TeacherRepository;
+import kr.pullgo.pullgoserver.service.helper.ServiceErrorHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TeacherAuthorizer extends AbstractAuthorizer {
+
+    private final AuthenticationInspector authInspector;
+    private final ServiceErrorHelper errorHelper;
+
+    @Autowired
+    public TeacherAuthorizer(
+        AuthenticationInspector authInspector,
+        StudentRepository studentRepository,
+        TeacherRepository teacherRepository,
+        ServiceErrorHelper errorHelper) {
+        super(authInspector, studentRepository, teacherRepository, errorHelper);
+        this.authInspector = authInspector;
+        this.errorHelper = errorHelper;
+    }
+
+    public void requireByOneselfOrMemberTeacher(Authentication authentication, Teacher teacher,
+        Academy academy) {
+        if (authInspector.isAdmin(authentication))
+            return;
+        Account account = authInspector.getAccountOrThrow(authentication);
+
+        Teacher requester = getTeacherOrThrow(account);
+        if (requester != teacher && !academy.getTeachers().contains(teacher)) {
+            throw errorHelper.forbidden("Not a member teacher or requested oneself");
+        }
+    }
+
+    public void requireByOneselfOrMemberTeacher(Authentication authentication, Teacher teacher,
+        Classroom classroom) {
+        if (authInspector.isAdmin(authentication))
+            return;
+        Account account = authInspector.getAccountOrThrow(authentication);
+
+        Teacher requester = getTeacherOrThrow(account);
+        if (requester != teacher && !classroom.getTeachers().contains(teacher)) {
+            throw errorHelper.forbidden("Not a member teacher or requested oneself");
+        }
+    }
+
+}

--- a/src/main/java/kr/pullgo/pullgoserver/service/helper/ServiceErrorHelper.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/helper/ServiceErrorHelper.java
@@ -15,4 +15,8 @@ public class ServiceErrorHelper {
         return new ResponseStatusException(HttpStatus.BAD_REQUEST, reason);
     }
 
+    public ResponseStatusException unauthorized(String reason) {
+        return new ResponseStatusException(HttpStatus.UNAUTHORIZED, reason);
+    }
+
 }

--- a/src/main/java/kr/pullgo/pullgoserver/service/helper/ServiceErrorHelper.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/helper/ServiceErrorHelper.java
@@ -19,4 +19,7 @@ public class ServiceErrorHelper {
         return new ResponseStatusException(HttpStatus.UNAUTHORIZED, reason);
     }
 
+    public ResponseStatusException forbidden(String reason) {
+        return new ResponseStatusException(HttpStatus.FORBIDDEN, reason);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,8 @@ spring:
 logging:
   level:
     org.hibernate.type.descriptor.sql.BasicBinder: trace
+auth:
+  jwt:
+    key:
+      secret-string: ${JWT_SECRET}
+    expiration-interval: 604800   # a week

--- a/src/test/java/kr/pullgo/pullgoserver/AcademyIntegrationTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/AcademyIntegrationTest.java
@@ -18,6 +18,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -50,6 +51,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -95,6 +97,7 @@ public class AcademyIntegrationTest {
         H2DbCleaner.clean(dataSource);
 
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .apply(springSecurity())
             .apply(basicDocumentationConfiguration(restDocumentation))
             .build();
     }
@@ -470,6 +473,7 @@ public class AcademyIntegrationTest {
     class PostAcademy {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void postAcademy() throws Exception {
             // Given
             Long creatorId = trxHelper.doInTransaction(() -> {
@@ -510,6 +514,7 @@ public class AcademyIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void postAcademy_InvalidOwner_NotFoundStatus() throws Exception {
             // When
             AcademyDto.Create dto = anAcademyCreateDto().withOwnerId(0L);
@@ -530,6 +535,7 @@ public class AcademyIntegrationTest {
     class PatchAcademy {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void patchAcademy() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -588,6 +594,7 @@ public class AcademyIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void patchAcademy_AcademyNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(anAcademyUpdateDto());
@@ -602,6 +609,7 @@ public class AcademyIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void patchAcademy_InvalidOwner_NotFoundStatus() throws Exception {
             // When
             String body = toJson(anAcademyUpdateDto().withOwnerId(0L));
@@ -621,6 +629,7 @@ public class AcademyIntegrationTest {
     class DeleteAcademy {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void deleteAcademy() throws Exception {
             // Given
             Long academyId = trxHelper.doInTransaction(() -> {
@@ -657,6 +666,7 @@ public class AcademyIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void deleteAcademy_AcademyNotFound_NotFoundStatus() throws Exception {
             // When
             ResultActions actions = mockMvc.perform(delete("/academies/{id}", 0));
@@ -672,6 +682,7 @@ public class AcademyIntegrationTest {
     class AcceptTeacher {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void acceptTeacher() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -709,6 +720,7 @@ public class AcademyIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void acceptTeacher_AcademyNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(anAcademyAcceptTeacherDto());
@@ -724,6 +736,7 @@ public class AcademyIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void acceptTeacher_TeacherNotFound_NotFoundStatus() throws Exception {
             // Given
             Long academyId = trxHelper.doInTransaction(() -> {
@@ -745,6 +758,7 @@ public class AcademyIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void acceptTeacher_TeacherNotApplied_BadRequestStatus() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -776,6 +790,7 @@ public class AcademyIntegrationTest {
     class KickTeacher {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void kickTeacher() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -813,6 +828,7 @@ public class AcademyIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void kickTeacher_AcademyNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(anAcademyKickTeacherDto());
@@ -828,6 +844,7 @@ public class AcademyIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void kickTeacher_TeacherNotFound_NotFoundStatus() throws Exception {
             // Given
             Long academyId = trxHelper.doInTransaction(() -> {
@@ -849,6 +866,7 @@ public class AcademyIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void kickTeacher_TeacherNotEnrolled_BadRequestStatus() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -881,6 +899,7 @@ public class AcademyIntegrationTest {
     class AcceptStudent {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void acceptStudent() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -918,6 +937,7 @@ public class AcademyIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void acceptStudent_AcademyNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(anAcademyAcceptStudentDto());
@@ -933,6 +953,7 @@ public class AcademyIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void acceptStudent_StudentNotFound_NotFoundStatus() throws Exception {
             // Given
             Long academyId = trxHelper.doInTransaction(() -> {
@@ -954,6 +975,7 @@ public class AcademyIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void acceptStudent_StudentNotApplied_BadRequestStatus() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -986,6 +1008,7 @@ public class AcademyIntegrationTest {
     class KickStudent {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void kickStudent() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -1023,6 +1046,7 @@ public class AcademyIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void kickStudent_AcademyNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(anAcademyKickStudentDto());
@@ -1038,6 +1062,7 @@ public class AcademyIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void kickStudent_StudentNotFound_NotFoundStatus() throws Exception {
             // Given
             Long academyId = trxHelper.doInTransaction(() -> {
@@ -1059,6 +1084,7 @@ public class AcademyIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void kickStudent_StudentNotEnrolled_BadRequestStatus() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {

--- a/src/test/java/kr/pullgo/pullgoserver/AttenderAnswerIntegrationTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/AttenderAnswerIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -35,18 +36,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
-@AutoConfigureMockMvc
 public class AttenderAnswerIntegrationTest {
 
-    @Autowired
     private MockMvc mockMvc;
 
     @Autowired
@@ -65,8 +65,12 @@ public class AttenderAnswerIntegrationTest {
     private EntityHelper entityHelper;
 
     @BeforeEach
-    void setUp() throws SQLException {
+    void setUp(WebApplicationContext webApplicationContext) throws SQLException {
         H2DbCleaner.clean(dataSource);
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .apply(springSecurity())
+            .build();
     }
 
     @Nested
@@ -216,6 +220,7 @@ public class AttenderAnswerIntegrationTest {
     }
 
     @Test
+    @WithMockUser(authorities = "ADMIN")
     void postAttenderAnswer() throws Exception {
         // Given
         Struct given = trxHelper.doInTransaction(() -> {
@@ -256,6 +261,7 @@ public class AttenderAnswerIntegrationTest {
     class PatchAttenderAnswer {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void patchAttenderAnswer() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -296,6 +302,7 @@ public class AttenderAnswerIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void patchAttenderAnswer_AttenderAnswerNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(anAttenderAnswerUpdateDto());
@@ -315,6 +322,7 @@ public class AttenderAnswerIntegrationTest {
     class DeleteAttenderAnswer {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void deleteAttenderAnswer() throws Exception {
             // Given
             Long attenderAnswerId = trxHelper.doInTransaction(() -> {
@@ -335,6 +343,7 @@ public class AttenderAnswerIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void deleteAttenderAnswer_AttenderAnswerNotFound_NotFoundStatus() throws Exception {
             // When
             ResultActions actions = mockMvc.perform(delete("/exam/attender-state/answers/{id}", 0));

--- a/src/test/java/kr/pullgo/pullgoserver/AttenderStateIntegrationTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/AttenderStateIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -36,18 +37,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
-@AutoConfigureMockMvc
 public class AttenderStateIntegrationTest {
 
-    @Autowired
     private MockMvc mockMvc;
 
     @Autowired
@@ -66,8 +66,12 @@ public class AttenderStateIntegrationTest {
     private EntityHelper entityHelper;
 
     @BeforeEach
-    void setUp() throws SQLException {
+    void setUp(WebApplicationContext webApplicationContext) throws SQLException {
         H2DbCleaner.clean(dataSource);
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .apply(springSecurity())
+            .build();
     }
 
     @Nested
@@ -252,6 +256,7 @@ public class AttenderStateIntegrationTest {
     }
 
     @Test
+    @WithMockUser(authorities = "ADMIN")
     void postAttenderState() throws Exception {
         // Given
         Struct given = trxHelper.doInTransaction(() -> {
@@ -290,6 +295,7 @@ public class AttenderStateIntegrationTest {
     class PatchAttenderState {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void patchAttenderState() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -327,6 +333,7 @@ public class AttenderStateIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void patchAttenderState_AttenderStateNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(anAttenderStateUpdateDto());
@@ -346,6 +353,7 @@ public class AttenderStateIntegrationTest {
     class SubmitAttenderState {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void submitAttenderState() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -393,6 +401,7 @@ public class AttenderStateIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void submitAttenderState_BadAttendingProgress_BadRequestStatus() throws Exception {
             // Given
             Long attenderStateId = trxHelper.doInTransaction(() -> {
@@ -412,6 +421,7 @@ public class AttenderStateIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void submitAttenderState_AfterTimeLimit_BadRequestStatus() throws Exception {
             // Given
             Long attenderStateId = trxHelper.doInTransaction(() -> {
@@ -438,6 +448,7 @@ public class AttenderStateIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void submitAttenderState_AlreadyFinishedExam_BadRequestStatus() throws Exception {
             // Given
             Long attenderStateId = trxHelper.doInTransaction(() -> {
@@ -461,6 +472,7 @@ public class AttenderStateIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void submitAttenderState_AlreadyCancelled_BadRequestStatus() throws Exception {
             // Given
             Long attenderStateId = trxHelper.doInTransaction(() -> {
@@ -484,6 +496,7 @@ public class AttenderStateIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void submitAttenderState_AfterTimeRange_BadRequestStatus() throws Exception {
             // Given
             Long attenderStateId = trxHelper.doInTransaction(() -> {
@@ -512,6 +525,7 @@ public class AttenderStateIntegrationTest {
     class DeleteAttenderState {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void deleteAttenderState() throws Exception {
             // Given
             Long attenderStateId = trxHelper.doInTransaction(() -> {
@@ -532,6 +546,7 @@ public class AttenderStateIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void deleteAttenderState_AttenderStateNotFound_NotFoundStatus() throws Exception {
             // When
             ResultActions actions = mockMvc.perform(delete("/exam/attender-states/{id}", 0));

--- a/src/test/java/kr/pullgo/pullgoserver/AuthIntegrationTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/AuthIntegrationTest.java
@@ -1,0 +1,215 @@
+package kr.pullgo.pullgoserver;
+
+import static kr.pullgo.pullgoserver.docs.ApiDocumentation.basicDocumentationConfiguration;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import kr.pullgo.pullgoserver.config.security.UserPrincipal;
+import kr.pullgo.pullgoserver.dto.AuthDto;
+import kr.pullgo.pullgoserver.helper.EntityHelper;
+import kr.pullgo.pullgoserver.helper.Struct;
+import kr.pullgo.pullgoserver.helper.TransactionHelper;
+import kr.pullgo.pullgoserver.persistence.model.Account;
+import kr.pullgo.pullgoserver.persistence.model.Student;
+import kr.pullgo.pullgoserver.service.JwtService;
+import kr.pullgo.pullgoserver.util.H2DbCleaner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ExtendWith(RestDocumentationExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+public class AuthIntegrationTest {
+
+    private static final FieldDescriptor DOC_FIELD_STUDENT = subsectionWithPath("student")
+        .type("Student").description("계정을 소유한 학생 (학생 계정이 아니면 `null`)");
+    private static final FieldDescriptor DOC_FIELD_TEACHER = subsectionWithPath("teacher")
+        .type("Teacher").description("계정을 소유한 선생님 (선생님 계정이 아니면 `null`)");
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JwtService jwtService;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private TransactionHelper trxHelper;
+
+    @Autowired
+    private EntityHelper entityHelper;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext,
+        RestDocumentationContextProvider restDocumentation) throws SQLException {
+        H2DbCleaner.clean(dataSource);
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .apply(springSecurity())
+            .apply(basicDocumentationConfiguration(restDocumentation))
+            .build();
+    }
+
+    @Test
+    void generateToken() throws Exception {
+        // Given
+        Struct given = trxHelper.doInTransaction(() -> {
+            Account account = entityHelper.generateAccount(it ->
+                it.withUsername("test1234")
+                    .withPassword(encodedPassword("pAsSwOrD"))
+            );
+            Student student = entityHelper.generateStudent(it -> it.withAccount(account));
+
+            return new Struct()
+                .withValue("accountId", account.getId())
+                .withValue("studentId", student.getId());
+        });
+        Long accountId = given.valueOf("accountId");
+        Long studentId = given.valueOf("studentId");
+
+        // When
+        AuthDto.GenerateToken dto = AuthDto.GenerateToken.builder()
+            .username("test1234")
+            .password("pAsSwOrD")
+            .build();
+        String body = toJson(dto);
+
+        ResultActions actions = mockMvc.perform(post("/auth/token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body));
+
+        // Then
+        MvcResult result = actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.token").isString())
+            .andExpect(jsonPath("$.student.id").value(studentId))
+            .andReturn();
+
+        String responseBody = result.getResponse().getContentAsString();
+        AuthDto.GenerateTokenResult resultDto = fromJson(responseBody,
+            AuthDto.GenerateTokenResult.class);
+
+        UserPrincipal principal = jwtService.extractSubject(resultDto.getToken());
+        assertThat(principal.getAccountId()).isEqualTo(accountId);
+
+        // Document
+        actions.andDo(document("auth-generate-token-example",
+            requestFields(
+                fieldWithPath("username").description("사용자 이름"),
+                fieldWithPath("password").description("비밀번호")
+            ),
+            responseFields(
+                fieldWithPath("token").description("액세스 토큰"),
+                DOC_FIELD_STUDENT,
+                DOC_FIELD_TEACHER
+            )));
+    }
+
+    @Test
+    void generateToken_InvalidPassword_UnauthorizedStatus() throws Exception {
+        // Given
+        trxHelper.doInTransaction(() -> {
+            Account account = entityHelper.generateAccount(it ->
+                it.withUsername("test1234")
+                    .withPassword(encodedPassword("pAsSwOrD"))
+            );
+            entityHelper.generateStudent(it -> it.withAccount(account));
+        });
+
+        // When
+        AuthDto.GenerateToken dto = AuthDto.GenerateToken.builder()
+            .username("test1234")
+            .password("wrongPassword")
+            .build();
+        String body = toJson(dto);
+
+        ResultActions actions = mockMvc.perform(post("/auth/token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body));
+
+        // Then
+        actions
+            .andExpect(status().isUnauthorized())
+            .andReturn();
+    }
+
+    @Test
+    void getMe() throws Exception {
+        // Given
+        Struct given = trxHelper.doInTransaction(() -> {
+            Account account = entityHelper.generateAccount(it ->
+                it.withUsername("test1234")
+                    .withPassword(encodedPassword("pAsSwOrD"))
+            );
+            Student student = entityHelper.generateStudent(it -> it.withAccount(account));
+
+            return new Struct()
+                .withValue("token", jwtService.signJwt(account))
+                .withValue("studentId", student.getId());
+        });
+        String token = given.valueOf("token");
+        Long studentId = given.valueOf("studentId");
+
+        // When
+        ResultActions actions = mockMvc.perform(get("/auth/me")
+            .header("Authorization", "Bearer " + token));
+
+        // Then
+        actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.student.id").value(studentId))
+            .andReturn();
+
+        // Document
+        actions.andDo(document("auth-me-example",
+            responseFields(
+                DOC_FIELD_STUDENT,
+                DOC_FIELD_TEACHER
+            )));
+    }
+
+    private String toJson(Object object) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(object);
+    }
+
+    private <T> T fromJson(String json, Class<T> clazz) throws JsonProcessingException {
+        return objectMapper.readValue(json, clazz);
+    }
+
+    private String encodedPassword(String password) {
+        return passwordEncoder.encode(password);
+    }
+
+}

--- a/src/test/java/kr/pullgo/pullgoserver/ClassroomIntegrationTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/ClassroomIntegrationTest.java
@@ -17,6 +17,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -54,6 +55,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -100,6 +102,7 @@ public class ClassroomIntegrationTest {
         H2DbCleaner.clean(dataSource);
 
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .apply(springSecurity())
             .apply(basicDocumentationConfiguration(restDocumentation))
             .build();
     }
@@ -467,6 +470,7 @@ public class ClassroomIntegrationTest {
     }
 
     @Test
+    @WithMockUser(authorities = "ADMIN")
     void postClassroom() throws Exception {
         // Given
         Struct given = trxHelper.doInTransaction(() -> {
@@ -524,6 +528,7 @@ public class ClassroomIntegrationTest {
     class PatchClassroom {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void patchClassroom() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -566,6 +571,7 @@ public class ClassroomIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void patchClassroom_ClassroomNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(aClassroomUpdateDto());
@@ -585,6 +591,7 @@ public class ClassroomIntegrationTest {
     class DeleteClassroom {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void deleteClassroom() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -642,6 +649,7 @@ public class ClassroomIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void deleteClassroom_ClassroomNotFound_NotFoundStatus() throws Exception {
             // When
             ResultActions actions = mockMvc.perform(delete("/academy/classrooms/{id}", 0));
@@ -657,6 +665,7 @@ public class ClassroomIntegrationTest {
     class AcceptTeacher {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void acceptTeacher() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -695,6 +704,7 @@ public class ClassroomIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void acceptTeacher_ClassroomNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(aClassroomAcceptTeacherDto());
@@ -710,6 +720,7 @@ public class ClassroomIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void acceptTeacher_TeacherNotFound_NotFoundStatus() throws Exception {
             // Given
             Long classroomId = trxHelper.doInTransaction(() -> {
@@ -731,6 +742,7 @@ public class ClassroomIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void acceptTeacher_TeacherNotApplied_BadRequestStatus() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -762,6 +774,7 @@ public class ClassroomIntegrationTest {
     class KickTeacher {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void kickTeacher() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -799,6 +812,7 @@ public class ClassroomIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void kickTeacher_ClassroomNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(aClassroomKickTeacherDto());
@@ -814,6 +828,7 @@ public class ClassroomIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void kickTeacher_TeacherNotFound_NotFoundStatus() throws Exception {
             // Given
             Long classroomId = trxHelper.doInTransaction(() -> {
@@ -835,6 +850,7 @@ public class ClassroomIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void kickTeacher_TeacherNotEnrolled_BadRequestStatus() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -867,6 +883,7 @@ public class ClassroomIntegrationTest {
     class AcceptStudent {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void acceptStudent() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -905,6 +922,7 @@ public class ClassroomIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void acceptStudent_ClassroomNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(aClassroomAcceptStudentDto());
@@ -920,6 +938,7 @@ public class ClassroomIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void acceptStudent_StudentNotFound_NotFoundStatus() throws Exception {
             // Given
             Long classroomId = trxHelper.doInTransaction(() -> {
@@ -941,6 +960,7 @@ public class ClassroomIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void acceptStudent_StudentNotApplied_BadRequestStatus() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -973,6 +993,7 @@ public class ClassroomIntegrationTest {
     class KickStudent {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void kickStudent() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -1010,6 +1031,7 @@ public class ClassroomIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void kickStudent_ClassroomNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(aClassroomKickStudentDto());
@@ -1025,6 +1047,7 @@ public class ClassroomIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void kickStudent_StudentNotFound_NotFoundStatus() throws Exception {
             // Given
             Long classroomId = trxHelper.doInTransaction(() -> {
@@ -1046,6 +1069,7 @@ public class ClassroomIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void kickStudent_StudentNotEnrolled_BadRequestStatus() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {

--- a/src/test/java/kr/pullgo/pullgoserver/ExamIntegrationTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/ExamIntegrationTest.java
@@ -13,6 +13,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -49,6 +50,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -102,6 +104,7 @@ public class ExamIntegrationTest {
         H2DbCleaner.clean(dataSource);
 
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .apply(springSecurity())
             .apply(basicDocumentationConfiguration(restDocumentation))
             .build();
     }
@@ -361,6 +364,7 @@ public class ExamIntegrationTest {
     }
 
     @Test
+    @WithMockUser(authorities = "ADMIN")
     void postExam() throws Exception {
         // Given
         Struct given = trxHelper.doInTransaction(() -> {
@@ -421,6 +425,7 @@ public class ExamIntegrationTest {
     class PatchExam {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void patchExam() throws Exception {
             // Given
             Long examId = trxHelper.doInTransaction(() -> {
@@ -470,6 +475,7 @@ public class ExamIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void patchExam_ExamNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(anExamUpdateDto());
@@ -489,6 +495,7 @@ public class ExamIntegrationTest {
     class DeleteExam {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void deleteExam() throws Exception {
             // Given
             Long examId = trxHelper.doInTransaction(() -> {
@@ -512,6 +519,7 @@ public class ExamIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void deleteExam_ExamNotFound_NotFoundStatus() throws Exception {
             // When
             ResultActions actions = mockMvc.perform(delete("/exams/{id}", 0));
@@ -527,6 +535,7 @@ public class ExamIntegrationTest {
     class CancelExam {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void cancelExam() throws Exception {
             // Given
             Long examId = trxHelper.doInTransaction(() -> {
@@ -555,6 +564,7 @@ public class ExamIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void cancelExam_ExamNotFound_NotFoundStatus() throws Exception {
             // When
             ResultActions actions = mockMvc.perform(post("/exams/{id}/cancel", 0));
@@ -565,6 +575,7 @@ public class ExamIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void cancelExam_ExamAlreadyFinished_BadRequestStatus() throws Exception {
             // Given
             Long examId = trxHelper.doInTransaction(() -> {
@@ -581,6 +592,7 @@ public class ExamIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void cancelExam_ExamAlreadyCancelled_BadRequestStatus() throws Exception {
             // Given
             Long examId = trxHelper.doInTransaction(() -> {
@@ -601,6 +613,7 @@ public class ExamIntegrationTest {
     class FinishExam {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void finishExam() throws Exception {
             // Given
             Long examId = trxHelper.doInTransaction(() -> {
@@ -629,6 +642,7 @@ public class ExamIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void finishExam_ExamNotFound_NotFoundStatus() throws Exception {
             // When
             ResultActions actions = mockMvc.perform(post("/exams/{id}/finish", 0));
@@ -639,6 +653,7 @@ public class ExamIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void finishExam_ExamAlreadyCancelled_BadRequestStatus() throws Exception {
             // Given
             Long examId = trxHelper.doInTransaction(() -> {
@@ -655,6 +670,7 @@ public class ExamIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void finishExam_ExamAlreadyFinished_BadRequestStatus() throws Exception {
             // Given
             Long examId = trxHelper.doInTransaction(() -> {

--- a/src/test/java/kr/pullgo/pullgoserver/LessonIntegrationTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/LessonIntegrationTest.java
@@ -13,6 +13,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -51,6 +52,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -96,6 +98,7 @@ public class LessonIntegrationTest {
         H2DbCleaner.clean(dataSource);
 
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .apply(springSecurity())
             .apply(basicDocumentationConfiguration(restDocumentation))
             .build();
     }
@@ -431,6 +434,7 @@ public class LessonIntegrationTest {
     }
 
     @Test
+    @WithMockUser(authorities = "ADMIN")
     void postLesson() throws Exception {
         // Given
         Long classroomId = trxHelper.doInTransaction(() -> {
@@ -480,6 +484,7 @@ public class LessonIntegrationTest {
     class PatchLesson {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void patchLesson() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -537,6 +542,7 @@ public class LessonIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void patchLesson_LessonNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(aLessonUpdateDto());
@@ -556,6 +562,7 @@ public class LessonIntegrationTest {
     class DeleteLesson {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void deleteLesson() throws Exception {
             // Given
             Long lessonId = trxHelper.doInTransaction(() -> {
@@ -579,6 +586,7 @@ public class LessonIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void deleteLesson_LessonNotFound_NotFoundStatus() throws Exception {
             // When
             ResultActions actions = mockMvc.perform(delete("/academy/classroom/lessons/{id}", 0));

--- a/src/test/java/kr/pullgo/pullgoserver/QuestionIntegrationTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/QuestionIntegrationTest.java
@@ -13,6 +13,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -48,6 +49,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -91,6 +93,7 @@ public class QuestionIntegrationTest {
         H2DbCleaner.clean(dataSource);
 
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .apply(springSecurity())
             .apply(basicDocumentationConfiguration(restDocumentation))
             .build();
     }
@@ -257,6 +260,7 @@ public class QuestionIntegrationTest {
     }
 
     @Test
+    @WithMockUser(authorities = "ADMIN")
     void postQuestion() throws Exception {
         // Given
         Long examId = trxHelper.doInTransaction(() -> {
@@ -300,6 +304,7 @@ public class QuestionIntegrationTest {
     class PatchQuestion {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void patchQuestion() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -347,6 +352,7 @@ public class QuestionIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void patchQuestion_QuestionNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(aQuestionUpdateDto());
@@ -366,6 +372,7 @@ public class QuestionIntegrationTest {
     class DeleteQuestion {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void deleteQuestion() throws Exception {
             // Given
             Long questionId = trxHelper.doInTransaction(() -> {
@@ -389,6 +396,7 @@ public class QuestionIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void deleteQuestion_QuestionNotFound_NotFoundStatus() throws Exception {
             // When
             ResultActions actions = mockMvc.perform(delete("/exam/questions/{id}", 0));

--- a/src/test/java/kr/pullgo/pullgoserver/StudentIntegrationTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/StudentIntegrationTest.java
@@ -17,6 +17,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -53,6 +54,7 @@ import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -105,6 +107,7 @@ public class StudentIntegrationTest {
         H2DbCleaner.clean(dataSource);
 
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .apply(springSecurity())
             .apply(basicDocumentationConfiguration(restDocumentation))
             .build();
     }
@@ -414,6 +417,7 @@ public class StudentIntegrationTest {
     }
 
     @Test
+    @WithMockUser(authorities = "ADMIN")
     void postStudent(@Autowired PasswordEncoder passwordEncoder) throws Exception {
         // When
         StudentDto.Create dto = StudentDto.Create.builder()
@@ -473,6 +477,7 @@ public class StudentIntegrationTest {
     class PatchStudent {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void patchStudent(@Autowired PasswordEncoder passwordEncoder) throws Exception {
             // Given
             Long studentId = trxHelper.doInTransaction(() -> {
@@ -544,6 +549,7 @@ public class StudentIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void patchStudent_StudentNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(aStudentUpdateDto());
@@ -563,6 +569,7 @@ public class StudentIntegrationTest {
     class DeleteStudent {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void deleteStudent() throws Exception {
             // Given
             Long studentId = trxHelper.doInTransaction(() -> {
@@ -596,6 +603,7 @@ public class StudentIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void deleteStudent_StudentNotFound_NotFoundStatus() throws Exception {
             // When
             ResultActions actions = mockMvc.perform(delete("/students/{id}", 0L));
@@ -611,6 +619,7 @@ public class StudentIntegrationTest {
     class ApplyAcademy {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void applyAcademy() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -644,6 +653,7 @@ public class StudentIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void applyAcademy_StudentNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(aStudentApplyAcademyDto());
@@ -659,6 +669,7 @@ public class StudentIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void applyAcademy_AcademyNotFound_NotFoundStatus() throws Exception {
             // Given
             Long studentId = trxHelper.doInTransaction(() -> {
@@ -680,6 +691,7 @@ public class StudentIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void applyAcademy_StudentAlreadyEnrolled_BadRequestStatus() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -714,6 +726,7 @@ public class StudentIntegrationTest {
     class RemoveAppliedAcademy {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void removeAppliedAcademy() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -750,6 +763,7 @@ public class StudentIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void removeAppliedAcademy_StudentNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(aStudentRemoveAppliedAcademyDto());
@@ -765,6 +779,7 @@ public class StudentIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void removeAppliedAcademy_AcademyNotFound_NotFoundStatus() throws Exception {
             // Given
             Long studentId = trxHelper.doInTransaction(() -> {
@@ -786,6 +801,7 @@ public class StudentIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void removeAppliedAcademy_StudentNotApplied_BadRequestStatus() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -817,6 +833,7 @@ public class StudentIntegrationTest {
     class ApplyClassroom {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void applyClassroom() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -850,6 +867,7 @@ public class StudentIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void applyClassroom_StudentNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(aStudentApplyClassroomDto());
@@ -865,6 +883,7 @@ public class StudentIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void applyClassroom_ClassroomNotFound_NotFoundStatus() throws Exception {
             // Given
             Long studentId = trxHelper.doInTransaction(() -> {
@@ -886,6 +905,7 @@ public class StudentIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void applyClassroom_StudentAlreadyEnrolled_BadRequestStatus() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -920,6 +940,7 @@ public class StudentIntegrationTest {
     class RemoveAppliedClassroom {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void removeAppliedClassroom() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -957,6 +978,7 @@ public class StudentIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void removeAppliedClassroom_StudentNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(aStudentRemoveAppliedClassroomDto());
@@ -972,6 +994,7 @@ public class StudentIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void removeAppliedClassroom_ClassroomNotFound_NotFoundStatus() throws Exception {
             // Given
             Long studentId = trxHelper.doInTransaction(() -> {
@@ -993,6 +1016,7 @@ public class StudentIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void removeAppliedClassroom_StudentNotApplied_BadRequestStatus() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {

--- a/src/test/java/kr/pullgo/pullgoserver/StudentIntegrationTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/StudentIntegrationTest.java
@@ -39,6 +39,7 @@ import kr.pullgo.pullgoserver.persistence.model.Academy;
 import kr.pullgo.pullgoserver.persistence.model.Account;
 import kr.pullgo.pullgoserver.persistence.model.Classroom;
 import kr.pullgo.pullgoserver.persistence.model.Student;
+import kr.pullgo.pullgoserver.persistence.model.UserRole;
 import kr.pullgo.pullgoserver.persistence.repository.StudentRepository;
 import kr.pullgo.pullgoserver.util.H2DbCleaner;
 import org.junit.jupiter.api.BeforeEach;
@@ -76,6 +77,8 @@ public class StudentIntegrationTest {
         fieldWithPath("account.fullName").description("실명");
     private static final FieldDescriptor DOC_FIELD_ACCOUNT_PHONE =
         fieldWithPath("account.phone").description("전화번호");
+    private static final FieldDescriptor DOC_FIELD_ACCOUNT_ROLE =
+        fieldWithPath("account.role").description("시스템 역할 (`USER`, `ADMIN`)");
 
     private MockMvc mockMvc;
 
@@ -115,6 +118,7 @@ public class StudentIntegrationTest {
                     it.withUsername("woodyn1002")
                         .withFullName("최우진")
                         .withPhone("01012345678")
+                        .withRole(UserRole.USER)
                 );
                 Student student = entityHelper.generateStudent(it ->
                     it.withAccount(account)
@@ -150,7 +154,8 @@ public class StudentIntegrationTest {
                     DOC_FIELD_SCHOOL_YEAR,
                     DOC_FIELD_ACCOUNT_USERNAME,
                     DOC_FIELD_ACCOUNT_FULL_NAME,
-                    DOC_FIELD_ACCOUNT_PHONE
+                    DOC_FIELD_ACCOUNT_PHONE,
+                    DOC_FIELD_ACCOUNT_ROLE
                 )));
         }
 

--- a/src/test/java/kr/pullgo/pullgoserver/TeacherIntegrationTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/TeacherIntegrationTest.java
@@ -39,6 +39,7 @@ import kr.pullgo.pullgoserver.persistence.model.Academy;
 import kr.pullgo.pullgoserver.persistence.model.Account;
 import kr.pullgo.pullgoserver.persistence.model.Classroom;
 import kr.pullgo.pullgoserver.persistence.model.Teacher;
+import kr.pullgo.pullgoserver.persistence.model.UserRole;
 import kr.pullgo.pullgoserver.persistence.repository.TeacherRepository;
 import kr.pullgo.pullgoserver.util.H2DbCleaner;
 import org.junit.jupiter.api.BeforeEach;
@@ -70,6 +71,8 @@ public class TeacherIntegrationTest {
         fieldWithPath("account.fullName").description("실명");
     private static final FieldDescriptor DOC_FIELD_ACCOUNT_PHONE =
         fieldWithPath("account.phone").description("전화번호");
+    private static final FieldDescriptor DOC_FIELD_ACCOUNT_ROLE =
+        fieldWithPath("account.role").description("시스템 역할 (`USER`, `ADMIN`)");
 
     private MockMvc mockMvc;
 
@@ -109,6 +112,7 @@ public class TeacherIntegrationTest {
                     it.withUsername("pte1024")
                         .withFullName("박태언")
                         .withPhone("01012345678")
+                        .withRole(UserRole.USER)
                 );
                 Teacher teacher = entityHelper.generateTeacher(it ->
                     it.withAccount(account)
@@ -135,7 +139,8 @@ public class TeacherIntegrationTest {
                     DOC_FIELD_ID,
                     DOC_FIELD_ACCOUNT_USERNAME,
                     DOC_FIELD_ACCOUNT_FULL_NAME,
-                    DOC_FIELD_ACCOUNT_PHONE
+                    DOC_FIELD_ACCOUNT_PHONE,
+                    DOC_FIELD_ACCOUNT_ROLE
                 )));
         }
 

--- a/src/test/java/kr/pullgo/pullgoserver/TeacherIntegrationTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/TeacherIntegrationTest.java
@@ -17,6 +17,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -53,6 +54,7 @@ import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -99,6 +101,7 @@ public class TeacherIntegrationTest {
         H2DbCleaner.clean(dataSource);
 
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .apply(springSecurity())
             .apply(basicDocumentationConfiguration(restDocumentation))
             .build();
     }
@@ -403,6 +406,7 @@ public class TeacherIntegrationTest {
     }
 
     @Test
+    @WithMockUser(authorities = "ADMIN")
     void postTeacher(@Autowired PasswordEncoder passwordEncoder) throws Exception {
         // When
         TeacherDto.Create dto = TeacherDto.Create.builder()
@@ -453,6 +457,7 @@ public class TeacherIntegrationTest {
     class PatchTeacher {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void patchTeacher(@Autowired PasswordEncoder passwordEncoder) throws Exception {
             // Given
             Long teacherId = trxHelper.doInTransaction(() -> {
@@ -512,6 +517,7 @@ public class TeacherIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void patchTeacher_TeacherNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(aTeacherUpdateDto());
@@ -531,6 +537,7 @@ public class TeacherIntegrationTest {
     class DeleteTeacher {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void deleteTeacher() throws Exception {
             // Given
             Long teacherId = trxHelper.doInTransaction(() -> {
@@ -564,6 +571,7 @@ public class TeacherIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void deleteTeacher_TeacherNotFound_NotFound_Status() throws Exception {
             // When
             ResultActions actions = mockMvc.perform(delete("/teachers/{id}", 0L));
@@ -579,6 +587,7 @@ public class TeacherIntegrationTest {
     class ApplyAcademy {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void applyAcademy() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -612,6 +621,7 @@ public class TeacherIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void applyAcademy_TeacherNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(aTeacherApplyAcademyDto());
@@ -627,6 +637,7 @@ public class TeacherIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void applyAcademy_AcademyNotFound_NotFoundStatus() throws Exception {
             // Given
             Long teacherId = trxHelper.doInTransaction(() -> {
@@ -648,6 +659,7 @@ public class TeacherIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void applyAcademy_TeacherAlreadyEnrolled_BadRequestStatus() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -682,6 +694,7 @@ public class TeacherIntegrationTest {
     class RemoveAppliedAcademy {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void removeAppliedAcademy() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -718,6 +731,7 @@ public class TeacherIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void removeAppliedAcademy_TeacherNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(aTeacherRemoveAppliedAcademyDto());
@@ -733,6 +747,7 @@ public class TeacherIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void removeAppliedAcademy_AcademyNotFound_NotFoundStatus() throws Exception {
             // Given
             Long teacherId = trxHelper.doInTransaction(() -> {
@@ -754,6 +769,7 @@ public class TeacherIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void removeAppliedAcademy_TeacherNotApplied_BadRequestStatus() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -785,6 +801,7 @@ public class TeacherIntegrationTest {
     class ApplyClassroom {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void applyClassroom() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -818,6 +835,7 @@ public class TeacherIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void applyClassroom_TeacherNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(aTeacherApplyClassroomDto());
@@ -833,6 +851,7 @@ public class TeacherIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void applyClassroom_ClassroomNotFound_NotFoundStatus() throws Exception {
             // Given
             Long teacherId = trxHelper.doInTransaction(() -> {
@@ -854,6 +873,7 @@ public class TeacherIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void applyClassroom_TeacherAlreadyEnrolled_BadRequestStatus() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -888,6 +908,7 @@ public class TeacherIntegrationTest {
     class RemoveAppliedClassroom {
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void removeAppliedClassroom() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
@@ -925,6 +946,7 @@ public class TeacherIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void removeAppliedClassroom_TeacherNotFound_NotFoundStatus() throws Exception {
             // When
             String body = toJson(aTeacherRemoveAppliedClassroomDto());
@@ -940,6 +962,7 @@ public class TeacherIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void removeAppliedClassroom_ClassroomNotFound_NotFoundStatus() throws Exception {
             // Given
             Long teacherId = trxHelper.doInTransaction(() -> {
@@ -961,6 +984,7 @@ public class TeacherIntegrationTest {
         }
 
         @Test
+        @WithMockUser(authorities = "ADMIN")
         void removeAppliedClassroom_TeacherNotApplied_BadRequestStatus() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {

--- a/src/test/java/kr/pullgo/pullgoserver/dto/mapper/AccountDtoMapperTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/dto/mapper/AccountDtoMapperTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import kr.pullgo.pullgoserver.dto.AccountDto;
 import kr.pullgo.pullgoserver.persistence.model.Account;
+import kr.pullgo.pullgoserver.persistence.model.UserRole;
 import org.junit.jupiter.api.Test;
 
 public class AccountDtoMapperTest {
@@ -37,6 +38,7 @@ public class AccountDtoMapperTest {
             .password("testpassword")
             .fullName("Test FullName")
             .phone("01012345678")
+            .role(UserRole.USER)
             .build();
         entity.setId(0L);
 
@@ -46,6 +48,7 @@ public class AccountDtoMapperTest {
         assertThat(dto.getUsername()).isEqualTo("testusername");
         assertThat(dto.getFullName()).isEqualTo("Test FullName");
         assertThat(dto.getPhone()).isEqualTo("01012345678");
+        assertThat(dto.getRole()).isEqualTo(UserRole.USER);
     }
 
 }

--- a/src/test/java/kr/pullgo/pullgoserver/helper/AccountHelper.java
+++ b/src/test/java/kr/pullgo/pullgoserver/helper/AccountHelper.java
@@ -2,6 +2,7 @@ package kr.pullgo.pullgoserver.helper;
 
 import kr.pullgo.pullgoserver.dto.AccountDto;
 import kr.pullgo.pullgoserver.persistence.model.Account;
+import kr.pullgo.pullgoserver.persistence.model.UserRole;
 
 public class AccountHelper {
 
@@ -16,6 +17,7 @@ public class AccountHelper {
             .password(ARBITRARY_PASSWORD)
             .fullName(ARBITRARY_FULL_NAME)
             .phone(ARBITRARY_PHONE)
+            .role(UserRole.USER)
             .build();
         account.setId(0L);
         return account;
@@ -43,6 +45,7 @@ public class AccountHelper {
             .username(ARBITRARY_USERNAME)
             .fullName(ARBITRARY_FULL_NAME)
             .phone(ARBITRARY_PHONE)
+            .role(UserRole.USER)
             .build();
     }
 

--- a/src/test/java/kr/pullgo/pullgoserver/service/JwtServiceTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/service/JwtServiceTest.java
@@ -1,0 +1,38 @@
+package kr.pullgo.pullgoserver.service;
+
+import static kr.pullgo.pullgoserver.helper.AccountHelper.anAccount;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import kr.pullgo.pullgoserver.config.security.UserPrincipal;
+import kr.pullgo.pullgoserver.persistence.model.Account;
+import org.junit.jupiter.api.Test;
+
+public class JwtServiceTest {
+
+    private static final String SECRET = "Z1VrWHAyczV2OHkvQj9FKEgrTWJRZVNoVm1ZcTN0Nnc=";
+    private static final int EXP_INTERVAL = 60 * 60 * 24 * 7; // a week
+
+    private final ObjectMapper objectMapper = new ObjectMapper()
+        .registerModule(new ParameterNamesModule());
+
+    private final JwtService jwtService = new JwtService(objectMapper, SECRET, EXP_INTERVAL);
+
+    @Test
+    void extractSubject() {
+        // Given
+        Account account = anAccount();
+        String jwt = jwtService.signJwt(account);
+
+        // When
+        UserPrincipal principal = jwtService.extractSubject(jwt);
+
+        // Then
+        assertThat(principal.getAccountId())
+            .isEqualTo(account.getId());
+
+        assertThat(principal.getUsername())
+            .isEqualTo(account.getUsername());
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -20,3 +20,8 @@ spring:
 logging:
   level:
     org.hibernate.type.descriptor.sql.BasicBinder: trace
+auth:
+  jwt:
+    key:
+      secret-string: Z1VrWHAyczV2OHkvQj9FKEgrTWJRZVNoVm1ZcTN0Nnc=
+    expiration-interval: 604800   # a week


### PR DESCRIPTION
close #88
아래 내용은 커밋 메시지와 동일함

# Account Entity에 role 필드 추가

시스템 역할(일반 사용자, 관리자 등)을 의미하는 필드가 필요해서 추가함
지금은 `USER`(일반 사용자)와 `ADMIN`(관리자)만 있음
인증/인가 구현 시 권한 확인에 사용될 정보임 (관리자는 모든 API를 호출할 수 있고, 일반 사용자는 자신이 소유한 리소스의 API만 호출할 수 있도록)

# 비밀번호 저장 시 암호화 적용

암호화 방식은 BCrypt 해시 함수를 사용함
* 보안에 취약한 일반 해시 함수보다는, `key derivation function`을 활용하는 편이 비밀번호 암호화에 적합함
* 다른 함수에 비해 구현이 쉬운 편임 (추후 보안 강화가 필요하면 개선하도록 함)

# 인증 기능 구현을 위한 `JwtService` 추가

* 인증 관련 클래스들을 `config.security` 패키지에 작성
  * `SecurityConfig` 클래스 이동
* jjwt 라이브러리를 의존성으로 추가 (JWT를 서명하고 파싱하는 기능을 위함)
  * 다른 라이브러리에 비해 간결하고 가독성이 높은 API를 제공함
* 사용자 인증 정보를 담기 위한 `UserPrincipal` 클래스 작성
  * `Account`의 `id`와 `username` 필드를 담고 있음
  * JWT 서명 시 직렬화되어 payload에 담김
    * 클라이언트가 이후 요청에서 JWT를 제공하면, 역직렬화를 통해 사용자 신원 정보를 확인함
* JWT 서명과 파싱을 위한 `JwtService` 클래스 작성
  * HMAC-SHA256 방식으로 JWT를 서명함
    * 아직 애플리케이션의 규모가 작아, 대칭키 구현으로도 충분하다고 판단함
    * 현실적으로 SHA-256 해시 함수로 인한 취약점이 무시 가능한 수준이라고 판단함
      * 그러나 비대칭키 방식이 훨씬 안전하므로, 추후 개선하도록 함
    * `application.yml`의 `auth.jwt.key.secret-string` 값을 secret으로 함
  * 서명 시 `sub` Claim으로 `UserPrincipal`을 json으로 직렬화하여 저장함

# Spring Security 인증 필터 추가

* `SecurityConfig`에 인증 관련 설정 추가
  * `BearerTokenAuthenticationFilter` Security Filter 추가
    * DispatcherServlet으로 요청이 전송될 때, Spring Security의 Filter가 미리 정의된 여러 Security Filter들을 실행하면서 사용자의 인증 정보를 추출함
    * 이때 추가적으로 적용된 `BearerTokenAuthenticationFilter`에서, `Authorization` 헤더로부터 JWT 문자열을 추출함 (헤더 내용은 `Authorization: Bearer TOKEN_HERE` 형식)
  * `JwtAuthenticationProvider` Authentication Provider 추가
    * Spring Security는 추출했던 사용자 인증 정보들을 토대로, 여러 Authentication Provider들을 통해 Security Context에 인증 정보를 설정함
    * 이때 추가적으로 적용된 `JwtAuthenticationProvider`에서, 추출했던 JWT의 유효성을 검사하며, 동시에 payload를 추출하여 `UserPrincipal`을 역직렬화 해냄
    * `UserPrincipal`을 Principal로 취급하는 `Authentication` 객체를 생성하고, 이를 Security Context에 설정함
    * 인증을 정상적으로 마치면, HTTP 요청이 처리되는 동안 `SecurityContextHolder.getContext().getAuthentication().getPrincipal()`을 통해, 사용자 신원이 담긴 `UserPrincipal` 인스턴스를 획득할 수 있음

# 인증 API 추가

* `POST /auth/token` API 추가
  * username과 password로 JWT를 서명하고, 해당하는 학생 혹은 선생님 정보를 제공함
* `GET /auth/me` API 추가
  * 헤더에 기입한 JWT를 기반으로, 토큰을 소유한 사용자의 정보를 제공함

# 인가 기능 구현

* `Authorizer` 컴포넌트들 추가
  * 주어진 신원 정보가 특정 권한을 갖고 있는지 판단하는 컴포넌트
    * 권한이 없으면 `403 Forbidden` 반환
  * `AbstractAuthorizer`: 권한 검증 중복 로직을 통합하기 위한 추상 클래스
  * `AuthenticationInspector`: `Authentication`에서 신원 정보를 추출하기 위한 컴포넌트
* 기존 API 서비스 로직에 `Authorizer`를 통한 검증 로직 추가
  * API마다 특정 권한을 요구하도록 만듬
* Controller에서 `Authentication` 객체를 Service로 전달하도록 수정
  * HTTP 요청의 인증 정보를 획득하여, 인가 기능을 위해 Service의 메소드에 인자로 전달
  * 서비스 내부에서 `SecurityContext.getAuthentication()` 메소드로 `Authentication`을 획득할 수도 있지만, 이는 테스트 작성 시 격리를 어렵게 만드므로 지양함

# API 문서에 인증과 인가 기능에 대한 서술 추가