### PR TITLE
Make lesson know academy

### DIFF
--- a/src/main/java/kr/pullgo/pullgoserver/dto/LessonDto.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/LessonDto.java
@@ -48,5 +48,8 @@ public interface LessonDto {
 
         @NotNull
         private ScheduleDto.Result schedule;
+
+        @NotNull
+        private Long academyId;
     }
 }

--- a/src/main/java/kr/pullgo/pullgoserver/dto/mapper/LessonDtoMapper.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/mapper/LessonDtoMapper.java
@@ -31,6 +31,7 @@ public class LessonDtoMapper implements DtoMapper<Lesson, LessonDto.Create, Less
             .schedule(scheduleDtoMapper.asResultDto(lesson.getSchedule()))
             .name(lesson.getName())
             .classroomId(lesson.getClassroom().getId())
+            .academyId(lesson.getClassroom().getAcademy().getId())
             .build();
     }
 

--- a/src/test/java/kr/pullgo/pullgoserver/LessonIntegrationTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/LessonIntegrationTest.java
@@ -68,6 +68,8 @@ public class LessonIntegrationTest {
         fieldWithPath("name").description("수업 이름");
     private static final FieldDescriptor DOC_FIELD_CLASSROOM_ID =
         fieldWithPath("classroomId").description("소속된 반 ID");
+    private static final FieldDescriptor DOC_FIELD_ACADEMY_ID =
+        fieldWithPath("academyId").description("소속된 학원 ID");
     private static final FieldDescriptor DOC_FIELD_SCHEDULE_DATE =
         fieldWithPath("schedule.date").description("수업 날짜");
     private static final FieldDescriptor DOC_FIELD_SCHEDULE_BEGIN_TIME =
@@ -122,10 +124,13 @@ public class LessonIntegrationTest {
 
                 return new Struct()
                     .withValue("lessonId", lesson.getId())
+                    .withValue("academyId", lesson.getClassroom().getAcademy().getId())
                     .withValue("classroomId", lesson.getClassroom().getId());
+
             });
             Long lessonId = given.valueOf("lessonId");
             Long classroomId = given.valueOf("classroomId");
+            Long academyId = given.valueOf("academyId");
 
             // When
             ResultActions actions = mockMvc
@@ -137,6 +142,7 @@ public class LessonIntegrationTest {
                 .andExpect(jsonPath("$.id").value(lessonId))
                 .andExpect(jsonPath("$.name").value("5월 13일 4시 반 수업"))
                 .andExpect(jsonPath("$.classroomId").value(classroomId))
+                .andExpect(jsonPath("$.academyId").value(academyId))
                 .andExpect(jsonPath("$.schedule.id").doesNotExist())
                 .andExpect(jsonPath("$.schedule.date").value("2021-05-13"))
                 .andExpect(jsonPath("$.schedule.beginTime").value("16:30:00"))
@@ -148,6 +154,7 @@ public class LessonIntegrationTest {
                     DOC_FIELD_ID,
                     DOC_FIELD_NAME,
                     DOC_FIELD_CLASSROOM_ID,
+                    DOC_FIELD_ACADEMY_ID,
                     DOC_FIELD_SCHEDULE_DATE,
                     DOC_FIELD_SCHEDULE_BEGIN_TIME,
                     DOC_FIELD_SCHEDULE_END_TIME


### PR DESCRIPTION
close #101
아래 내용은 커밋 메시지와 동일함
# Lesson Dto의 Result에 academy id 추가

Lesson 조회시 해당 Lesson이 속한 Academy로의 좀 더 빠른 접근을 원하는 클라이언트의 요구사항을 반영
* Classroom에 접근하여 Academy에 접근해야했던 기존의 방식을 개선