### PR TITLE
엑세스토큰 발급시 계정이 두개생성되던 문제 수정

### DIFF
--- a/src/main/java/kr/pullgo/pullgoserver/service/StudentService.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/StudentService.java
@@ -56,10 +56,9 @@ public class StudentService {
 
     @Transactional
     public StudentDto.Result create(StudentDto.Create dto) {
-        Student student = studentRepository.save(dtoMapper.asEntity(dto));
-
+        Student student = dtoMapper.asEntity(dto);
         student.setAccount(accountService.create(dto.getAccount()));
-
+        studentRepository.save(student);
         return dtoMapper.asResultDto(student);
     }
 

--- a/src/main/java/kr/pullgo/pullgoserver/service/TeacherService.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/TeacherService.java
@@ -1,15 +1,19 @@
 package kr.pullgo.pullgoserver.service;
 
 import java.util.List;
+
 import kr.pullgo.pullgoserver.dto.TeacherDto;
+import kr.pullgo.pullgoserver.dto.mapper.AccountDtoMapper;
 import kr.pullgo.pullgoserver.dto.mapper.TeacherDtoMapper;
 import kr.pullgo.pullgoserver.error.exception.AcademyNotFoundException;
 import kr.pullgo.pullgoserver.error.exception.ClassroomNotFoundException;
 import kr.pullgo.pullgoserver.error.exception.TeacherAlreadyEnrolledException;
 import kr.pullgo.pullgoserver.persistence.model.Academy;
+import kr.pullgo.pullgoserver.persistence.model.Account;
 import kr.pullgo.pullgoserver.persistence.model.Classroom;
 import kr.pullgo.pullgoserver.persistence.model.Teacher;
 import kr.pullgo.pullgoserver.persistence.repository.AcademyRepository;
+import kr.pullgo.pullgoserver.persistence.repository.AccountRepository;
 import kr.pullgo.pullgoserver.persistence.repository.ClassroomRepository;
 import kr.pullgo.pullgoserver.persistence.repository.TeacherRepository;
 import kr.pullgo.pullgoserver.service.authorizer.TeacherAuthorizer;
@@ -37,13 +41,13 @@ public class TeacherService {
 
     @Autowired
     public TeacherService(TeacherDtoMapper dtoMapper,
-        AccountService accountService,
-        TeacherRepository teacherRepository,
-        AcademyRepository academyRepository,
-        ClassroomRepository classroomRepository,
-        RepositoryHelper repoHelper,
-        ServiceErrorHelper errorHelper,
-        TeacherAuthorizer teacherAuthorizer) {
+                          AccountService accountService,
+                          TeacherRepository teacherRepository,
+                          AcademyRepository academyRepository,
+                          ClassroomRepository classroomRepository,
+                          RepositoryHelper repoHelper,
+                          ServiceErrorHelper errorHelper,
+                          TeacherAuthorizer teacherAuthorizer) {
         this.dtoMapper = dtoMapper;
         this.accountService = accountService;
         this.teacherRepository = teacherRepository;
@@ -56,10 +60,9 @@ public class TeacherService {
 
     @Transactional
     public TeacherDto.Result create(TeacherDto.Create dto) {
-        Teacher teacher = teacherRepository.save(dtoMapper.asEntity(dto));
-
+        Teacher teacher = dtoMapper.asEntity(dto);
         teacher.setAccount(accountService.create(dto.getAccount()));
-
+        teacherRepository.save(teacher);
         return dtoMapper.asResultDto(teacher);
     }
 


### PR DESCRIPTION
 close #103

문제 타임라인

1. Teacher teacher = teacherRepository.save(dtoMapper.asEntity(dto));
- dtoMapper.asEntity에서 이미 Account가 매핑된 채로 나옴
- Account와 Teacher 영속화 (insert account, insert teacher)
- 영속화된 Teacher 반환

2. teacher.setAccount(accountService.create(dto.getAccount()));
- 이미 영속화된 teacher의 account를 수정
- 비영속화 상태의 새로운 account를 set

3. 트랜잭션 flush 시 teacher dirty-check
- teacher에 들어간 account 영속화 (insert account)
- teacher에서 수정된 account 반영 (update teacher)

teacher계정이 두개생성과 그에 따른 쿼리 오류 발생

따라서 위의 순서를 teacher를 account와 관계를 맺고 영속화 시키는 방법으로 수정
같은문제가 존재하는 student도 수정