### PR TITLE
post API 수정 및 Classroom get API 반환값 추가

### DIFF
--- a/src/main/java/kr/pullgo/pullgoserver/dto/ClassroomDto.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/ClassroomDto.java
@@ -52,6 +52,9 @@ public interface ClassroomDto {
 
         @NotNull
         private Long creatorId;
+
+        @NotNull
+        private String creatorFullName;
     }
 
 

--- a/src/main/java/kr/pullgo/pullgoserver/dto/QuestionDto.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/QuestionDto.java
@@ -1,5 +1,6 @@
 package kr.pullgo.pullgoserver.dto;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.validation.constraints.NotNull;
@@ -36,6 +37,18 @@ public interface QuestionDto {
 
         @NotNull
         private QuestionConfig questionConfig;
+    }
+
+    @Data
+    @Builder
+    @With
+    class MultipleCreate {
+
+        @NotNull
+        private Long examId;
+
+        @NotNull
+        private List<QuestionDto.QuestionConfig> questionConfigs;
     }
 
     @Data

--- a/src/main/java/kr/pullgo/pullgoserver/dto/QuestionDto.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/QuestionDto.java
@@ -12,10 +12,7 @@ public interface QuestionDto {
     @Data
     @Builder
     @With
-    class Create {
-
-        @NotNull
-        private Long examId;
+    class QuestionConfig {
 
         @NotNull
         private String content;
@@ -24,9 +21,21 @@ public interface QuestionDto {
 
         @NotNull
         private Set<Integer> answer;
-
         @NotNull
         private Map<String, String> choice;
+
+    }
+
+    @Data
+    @Builder
+    @With
+    class Create {
+
+        @NotNull
+        private Long examId;
+
+        @NotNull
+        private QuestionConfig questionConfig;
     }
 
     @Data
@@ -55,14 +64,6 @@ public interface QuestionDto {
         private Long examId;
 
         @NotNull
-        private String content;
-
-        private String pictureUrl;
-
-        @NotNull
-        private Set<Integer> answer;
-
-        @NotNull
-        private Map<String, String> choice;
+        private QuestionConfig questionConfig;
     }
 }

--- a/src/main/java/kr/pullgo/pullgoserver/dto/helper/DtoValidationCheckHelper.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/helper/DtoValidationCheckHelper.java
@@ -1,0 +1,46 @@
+package kr.pullgo.pullgoserver.dto.helper;
+
+import java.util.Collection;
+import java.util.Map;
+import kr.pullgo.pullgoserver.dto.QuestionDto;
+
+public class DtoValidationCheckHelper {
+
+    private static boolean hasNullOrEmpty(Object... datas) {
+        for (var data : datas) {
+            if (data instanceof Collection<?>) {
+                if (((Collection<?>) data).isEmpty()) {
+                    return true;
+                } else {
+                    for (var single : (Collection<?>) data) {
+                        if (hasNullOrEmpty(single))
+                            return true;
+                    }
+                }
+            } else if (data instanceof Map<?, ?>) {
+                if (((Map<?, ?>) data).isEmpty()) {
+                    return true;
+                }
+            } else if (data instanceof QuestionDto.QuestionConfig) {
+                return !isValid((QuestionDto.QuestionConfig) data);
+            } else {
+                if (data == null) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public static boolean isValid(QuestionDto.QuestionConfig dto) {
+        return !hasNullOrEmpty(dto.getContent(), dto.getAnswer(), dto.getChoice());
+    }
+
+    public static boolean isValid(QuestionDto.MultipleCreate dto) {
+        return !hasNullOrEmpty(dto.getExamId(), dto.getQuestionConfigs());
+    }
+
+    public static boolean isValid(QuestionDto.Create dto) {
+        return !hasNullOrEmpty(dto.getExamId(), dto.getQuestionConfig());
+    }
+}

--- a/src/main/java/kr/pullgo/pullgoserver/dto/mapper/ClassroomDtoMapper.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/mapper/ClassroomDtoMapper.java
@@ -21,6 +21,7 @@ public class ClassroomDtoMapper implements
             .id(classroom.getId())
             .name(classroom.getName())
             .creatorId(classroom.getCreator().getId())
+            .creatorFullName(classroom.getCreator().getAccount().getFullName())
             .academyId(classroom.getAcademy().getId())
             .build();
     }

--- a/src/main/java/kr/pullgo/pullgoserver/dto/mapper/QuestionDtoMapper.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/mapper/QuestionDtoMapper.java
@@ -13,10 +13,10 @@ public class QuestionDtoMapper implements
     @Override
     public Question asEntity(QuestionDto.Create dto) {
         return Question.builder()
-            .content(dto.getContent())
-            .pictureUrl(dto.getPictureUrl())
-            .answer(new Answer(dto.getAnswer()))
-            .multipleChoice(new MultipleChoice(dto.getChoice()))
+            .content(dto.getQuestionConfig().getContent())
+            .pictureUrl(dto.getQuestionConfig().getPictureUrl())
+            .answer(new Answer(dto.getQuestionConfig().getAnswer()))
+            .multipleChoice(new MultipleChoice(dto.getQuestionConfig().getChoice()))
             .build();
     }
 
@@ -25,10 +25,12 @@ public class QuestionDtoMapper implements
         return QuestionDto.Result.builder()
             .id(question.getId())
             .examId(question.getExam().getId())
-            .content(question.getContent())
-            .pictureUrl(question.getPictureUrl())
-            .answer(question.getAnswer().getObjectiveNumbers())
-            .choice(question.getMultipleChoice().getChoices())
+            .questionConfig(QuestionDto.QuestionConfig.builder()
+                .content(question.getContent())
+                .pictureUrl(question.getPictureUrl())
+                .answer(question.getAnswer().getObjectiveNumbers())
+                .choice(question.getMultipleChoice().getChoices())
+                .build())
             .build();
     }
 

--- a/src/main/java/kr/pullgo/pullgoserver/presentation/controller/QuestionController.java
+++ b/src/main/java/kr/pullgo/pullgoserver/presentation/controller/QuestionController.java
@@ -1,5 +1,6 @@
 package kr.pullgo.pullgoserver.presentation.controller;
 
+import java.util.ArrayList;
 import java.util.List;
 import javax.validation.Valid;
 import kr.pullgo.pullgoserver.dto.QuestionDto;
@@ -10,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 public class QuestionController {
@@ -32,10 +35,31 @@ public class QuestionController {
     }
 
     @PostMapping("/exam/questions")
-    @ResponseStatus(HttpStatus.CREATED)
-    public QuestionDto.Result post(@Valid @RequestBody QuestionDto.Create dto,
-        Authentication authentication) {
-        return questionService.create(dto, authentication);
+    public ResponseEntity<List<ResponseEntity<QuestionDto.Result>>> post(
+        Authentication authentication,
+        @Valid @RequestBody QuestionDto.MultipleCreate dto) {
+        boolean isError = false;
+        List<ResponseEntity<QuestionDto.Result>> results = new ArrayList<>();
+        for (var configDto : dto.getQuestionConfigs()) {
+            try {
+                results.add(new ResponseEntity<>(
+                    questionService.create(QuestionDto.Create.builder()
+                        .examId(dto.getExamId())
+                        .questionConfig(configDto).
+                        build(), authentication),
+                    HttpStatus.CREATED));
+            } catch (ResponseStatusException e) {
+                results.add(new ResponseEntity<>(QuestionDto.Result.builder()
+                    .examId(dto.getExamId())
+                    .questionConfig(configDto).
+                    build(), e.getStatus()));
+                isError = true;
+            }
+        }
+        if (isError)
+            return new ResponseEntity<>(results, HttpStatus.BAD_REQUEST);
+        else
+            return new ResponseEntity<>(results, HttpStatus.OK);
     }
 
     @GetMapping("/exam/questions")

--- a/src/main/java/kr/pullgo/pullgoserver/service/QuestionService.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/QuestionService.java
@@ -2,6 +2,7 @@ package kr.pullgo.pullgoserver.service;
 
 import java.util.List;
 import kr.pullgo.pullgoserver.dto.QuestionDto;
+import kr.pullgo.pullgoserver.dto.helper.DtoValidationCheckHelper;
 import kr.pullgo.pullgoserver.dto.mapper.QuestionDtoMapper;
 import kr.pullgo.pullgoserver.persistence.model.Answer;
 import kr.pullgo.pullgoserver.persistence.model.Exam;
@@ -10,6 +11,7 @@ import kr.pullgo.pullgoserver.persistence.model.Question;
 import kr.pullgo.pullgoserver.persistence.repository.QuestionRepository;
 import kr.pullgo.pullgoserver.service.authorizer.QuestionAuthorizer;
 import kr.pullgo.pullgoserver.service.helper.RepositoryHelper;
+import kr.pullgo.pullgoserver.service.helper.ServiceErrorHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -25,21 +27,27 @@ public class QuestionService {
     private final QuestionRepository questionRepository;
     private final RepositoryHelper repoHelper;
     private final QuestionAuthorizer questionAuthorizer;
+    private final ServiceErrorHelper errorHelper;
 
     @Autowired
     public QuestionService(
         QuestionDtoMapper dtoMapper,
         QuestionRepository questionRepository,
         RepositoryHelper repoHelper,
-        QuestionAuthorizer questionAuthorizer) {
+        QuestionAuthorizer questionAuthorizer,
+        ServiceErrorHelper errorHelper) {
         this.dtoMapper = dtoMapper;
         this.questionRepository = questionRepository;
         this.repoHelper = repoHelper;
         this.questionAuthorizer = questionAuthorizer;
+        this.errorHelper = errorHelper;
     }
 
     @Transactional
     public QuestionDto.Result create(QuestionDto.Create dto, Authentication authentication) {
+        if (!DtoValidationCheckHelper.isValid(dto)) {
+            throw errorHelper.badRequest("incomplete data body receive");
+        }
         Question question = dtoMapper.asEntity(dto);
 
         Exam exam = repoHelper.findExamOrThrow(dto.getExamId());

--- a/src/test/java/kr/pullgo/pullgoserver/ClassroomIntegrationTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/ClassroomIntegrationTest.java
@@ -69,7 +69,9 @@ public class ClassroomIntegrationTest {
     private static final FieldDescriptor DOC_FIELD_ID =
         fieldWithPath("id").description("반 ID");
     private static final FieldDescriptor DOC_FIELD_CREATOR_ID =
-        fieldWithPath("creatorId").description("생성한 선생님 ID");
+        fieldWithPath("creatorId").description("생성한 선생님의 teacher ID");
+    private static final FieldDescriptor DOC_FIELD_CREATOR_FULL_NAME =
+        fieldWithPath("creatorFullName").description("생성한 선생님 이름");
     private static final FieldDescriptor DOC_FIELD_NAME =
         fieldWithPath("name").description("반 이름");
     private static final FieldDescriptor DOC_FIELD_ACADEMY_ID =
@@ -128,11 +130,14 @@ public class ClassroomIntegrationTest {
                 return new Struct()
                     .withValue("academyId", academy.getId())
                     .withValue("classroomId", classroom.getId())
-                    .withValue("creatorId", classroom.getCreator().getId());
+                    .withValue("creatorId", classroom.getCreator().getId())
+                    .withValue("creatorFullName",
+                        classroom.getCreator().getAccount().getFullName());
             });
             Long academyId = given.valueOf("academyId");
             Long classroomId = given.valueOf("classroomId");
             Long creatorId = given.valueOf("creatorId");
+            String creatorFullName = given.valueOf("creatorFullName");
 
             // When
             ResultActions actions = mockMvc
@@ -144,7 +149,8 @@ public class ClassroomIntegrationTest {
                 .andExpect(jsonPath("$.id").value(classroomId))
                 .andExpect(jsonPath("$.creatorId").value(creatorId))
                 .andExpect(jsonPath("$.name").value("컴퓨터네트워크 최웅철 (월수금)"))
-                .andExpect(jsonPath("$.academyId").value(academyId));
+                .andExpect(jsonPath("$.academyId").value(academyId))
+                .andExpect(jsonPath("$.creatorFullName").value(creatorFullName));
 
             // Document
             actions.andDo(document("classroom-retrieve-example",
@@ -152,6 +158,7 @@ public class ClassroomIntegrationTest {
                     DOC_FIELD_ID,
                     DOC_FIELD_NAME,
                     DOC_FIELD_CREATOR_ID,
+                    DOC_FIELD_CREATOR_FULL_NAME,
                     DOC_FIELD_ACADEMY_ID
                 )));
         }
@@ -488,11 +495,13 @@ public class ClassroomIntegrationTest {
             return new Struct()
                 .withValue("token", token)
                 .withValue("academyId", academy.getId())
-                .withValue("creatorId", creator.getId());
+                .withValue("creatorId", creator.getId())
+                .withValue("creatorFullName", creator.getAccount().getFullName());
         });
         String token = given.valueOf("token");
         Long academyId = given.valueOf("academyId");
         Long creatorId = given.valueOf("creatorId");
+        String creatorFullName = given.valueOf("creatorFullName");
 
         // When
         ClassroomDto.Create dto = ClassroomDto.Create.builder()
@@ -514,6 +523,7 @@ public class ClassroomIntegrationTest {
             .andExpect(jsonPath("$.name").value("test name"))
             .andExpect(jsonPath("$.creatorId").value(creatorId))
             .andExpect(jsonPath("$.academyId").value(academyId))
+            .andExpect(jsonPath("$.creatorFullName").value(creatorFullName))
             .andReturn();
 
         String responseBody = mvcResult.getResponse().getContentAsString();

--- a/src/test/java/kr/pullgo/pullgoserver/dto/mapper/QuestionDtoMapperTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/dto/mapper/QuestionDtoMapperTest.java
@@ -20,11 +20,14 @@ class QuestionDtoMapperTest {
         // When
         QuestionDto.Create dto = QuestionDto.Create.builder()
             .examId(0L)
-            .content("test content")
-            .pictureUrl(null)
-            .answer(Set.of(1, 3))
-            .choice(Map.of(
-                "1", "1", "2", "2", "3", "3", "4", "4", "5", "5")).build();
+            .questionConfig(QuestionDto.QuestionConfig.builder()
+                .content("test content")
+                .pictureUrl(null)
+                .answer(Set.of(1, 3))
+                .choice(Map.of(
+                    "1", "1", "2", "2", "3", "3", "4", "4", "5", "5"))
+                .build())
+            .build();
 
         Question entity = dtoMapper.asEntity(dto);
 
@@ -43,7 +46,8 @@ class QuestionDtoMapperTest {
             .content("test content")
             .pictureUrl(null)
             .answer(new Answer(1, 3))
-            .multipleChoice(new MultipleChoice("test choice 1", "test choice 2", "test choice 3", "test choice 4", "test choice 5"))
+            .multipleChoice(new MultipleChoice("test choice 1", "test choice 2", "test choice 3",
+                "test choice 4", "test choice 5"))
             .build();
         entity.setId(0L);
         entity.setExam(anExam().withId(1L));
@@ -53,11 +57,12 @@ class QuestionDtoMapperTest {
         // Then
         assertThat(dto.getId()).isEqualTo(0L);
         assertThat(dto.getExamId()).isEqualTo(1L);
-        assertThat(dto.getContent()).isEqualTo("test content");
-        assertThat(dto.getPictureUrl()).isNull();
-        assertThat(dto.getAnswer()).containsOnly(1, 3);
-        assertThat(dto.getChoice()).isEqualTo(Map.of(
-            "1", "test choice 1", "2", "test choice 2", "3", "test choice 3", "4", "test choice 4", "5", "test choice 5"));
+        assertThat(dto.getQuestionConfig().getContent()).isEqualTo("test content");
+        assertThat(dto.getQuestionConfig().getPictureUrl()).isNull();
+        assertThat(dto.getQuestionConfig().getAnswer()).containsOnly(1, 3);
+        assertThat(dto.getQuestionConfig().getChoice()).isEqualTo(Map.of(
+            "1", "test choice 1", "2", "test choice 2", "3", "test choice 3", "4", "test choice 4",
+            "5", "test choice 5"));
     }
 
 }

--- a/src/test/java/kr/pullgo/pullgoserver/helper/ClassroomHelper.java
+++ b/src/test/java/kr/pullgo/pullgoserver/helper/ClassroomHelper.java
@@ -9,6 +9,7 @@ import kr.pullgo.pullgoserver.persistence.model.Classroom;
 public class ClassroomHelper {
 
     private static final String ARBITRARY_NAME = "컴퓨터네트워크 최웅철 (월수금)";
+    private static final String ARBITRARY_CREATOR_FULL_NAME = "최웅철";
 
     public static Classroom aClassroom() {
         Classroom classroom = Classroom.builder()
@@ -38,6 +39,7 @@ public class ClassroomHelper {
         return ClassroomDto.Result.builder()
             .id(0L)
             .academyId(0L)
+            .creatorFullName(ARBITRARY_CREATOR_FULL_NAME)
             .creatorId(0L)
             .name(ARBITRARY_NAME)
             .build();

--- a/src/test/java/kr/pullgo/pullgoserver/helper/QuestionHelper.java
+++ b/src/test/java/kr/pullgo/pullgoserver/helper/QuestionHelper.java
@@ -35,6 +35,12 @@ public class QuestionHelper {
     public static QuestionDto.Create aQuestionCreateDto() {
         return QuestionDto.Create.builder()
             .examId(0L)
+            .questionConfig(aQuestionConfigDto())
+            .build();
+    }
+
+    public static QuestionDto.QuestionConfig aQuestionConfigDto() {
+        return QuestionDto.QuestionConfig.builder()
             .content(ARBITRARY_CONTENT)
             .pictureUrl(ARBITRARY_PICTURE_URL)
             .answer(ARBITRARY_ANSWER)
@@ -55,10 +61,7 @@ public class QuestionHelper {
         return QuestionDto.Result.builder()
             .id(0L)
             .examId(0L)
-            .content(ARBITRARY_CONTENT)
-            .pictureUrl(ARBITRARY_PICTURE_URL)
-            .answer(ARBITRARY_ANSWER)
-            .choice(ARBITRARY_MULTIPLE_CHOICE)
+            .questionConfig(aQuestionConfigDto())
             .build();
     }
 

--- a/src/test/java/kr/pullgo/pullgoserver/helper/QuestionHelper.java
+++ b/src/test/java/kr/pullgo/pullgoserver/helper/QuestionHelper.java
@@ -2,6 +2,7 @@ package kr.pullgo.pullgoserver.helper;
 
 import static kr.pullgo.pullgoserver.helper.ExamHelper.anExam;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import kr.pullgo.pullgoserver.dto.QuestionDto;
@@ -45,6 +46,16 @@ public class QuestionHelper {
             .pictureUrl(ARBITRARY_PICTURE_URL)
             .answer(ARBITRARY_ANSWER)
             .choice(ARBITRARY_MULTIPLE_CHOICE)
+            .build();
+    }
+
+    public static QuestionDto.MultipleCreate multipleQuestionCreateDto() {
+        return QuestionDto.MultipleCreate.builder()
+            .examId(0L)
+            .questionConfigs(List.of(
+                aQuestionConfigDto(),
+                aQuestionConfigDto(),
+                aQuestionConfigDto()))
             .build();
     }
 


### PR DESCRIPTION
close #122 
## post API 수정
기존의 Question의 post API는 하나의 question만 생성하는 요청이었다. 
그러나 일반적으로 Exam생성시 추가되는 Question의 양은 복수의 Question일것으로 예상된다. 게다가 그런 예상되는 방법으로 Exam을 생성할 경우 한번에 여러개의 Question을 Exam에 추가하는 방식이 클라이언트 측에 좀 더 나은 방식으로 예상된다.

## get API creatorFullName반환값 추가
기존의 방식은 creator의 fullName변경시 classroom의 name을 같이 변경해주는데 효과적이지 못했다. 
classroom의 name 양식에서 creatorFullName을 제거하고, creatorFullName은 따로 받게된다면 creator의 변화에 조금 더 유연할것으로 예상된다.