### PR TITLE
ClassroomDto.Result의 creatorId 를 creaoter로 변경

### DIFF
--- a/src/main/java/kr/pullgo/pullgoserver/dto/ClassroomDto.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/ClassroomDto.java
@@ -51,7 +51,7 @@ public interface ClassroomDto {
         private String name;
 
         @NotNull
-        private Long creatorId;
+        private TeacherDto.Result creator;
     }
 
 

--- a/src/main/java/kr/pullgo/pullgoserver/dto/mapper/ClassroomDtoMapper.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/mapper/ClassroomDtoMapper.java
@@ -20,7 +20,7 @@ public class ClassroomDtoMapper implements
         return ClassroomDto.Result.builder()
             .id(classroom.getId())
             .name(classroom.getName())
-            .creatorId(classroom.getCreator().getId())
+            .creator(teacherDtoMapper.asResultDto(classroom.getCreator()))
             .academyId(classroom.getAcademy().getId())
             .build();
     }

--- a/src/main/java/kr/pullgo/pullgoserver/dto/mapper/ClassroomDtoMapper.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/mapper/ClassroomDtoMapper.java
@@ -2,11 +2,19 @@ package kr.pullgo.pullgoserver.dto.mapper;
 
 import kr.pullgo.pullgoserver.dto.ClassroomDto;
 import kr.pullgo.pullgoserver.persistence.model.Classroom;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ClassroomDtoMapper implements
     DtoMapper<Classroom, ClassroomDto.Create, ClassroomDto.Result> {
+
+    private final TeacherDtoMapper teacherDtoMapper;
+
+    @Autowired
+    public ClassroomDtoMapper(TeacherDtoMapper teacherDtoMapper) {
+        this.teacherDtoMapper = teacherDtoMapper;
+    }
 
     @Override
     public Classroom asEntity(ClassroomDto.Create dto) {

--- a/src/test/java/kr/pullgo/pullgoserver/dto/mapper/ClassroomDtoMapperTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/dto/mapper/ClassroomDtoMapperTest.java
@@ -2,15 +2,28 @@ package kr.pullgo.pullgoserver.dto.mapper;
 
 import static kr.pullgo.pullgoserver.helper.AcademyHelper.anAcademy;
 import static kr.pullgo.pullgoserver.helper.TeacherHelper.aTeacher;
+import static kr.pullgo.pullgoserver.helper.TeacherHelper.aTeacherResultDto;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 import kr.pullgo.pullgoserver.dto.ClassroomDto;
 import kr.pullgo.pullgoserver.persistence.model.Classroom;
+import kr.pullgo.pullgoserver.persistence.model.Teacher;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class ClassroomDtoMapperTest {
 
-    private final ClassroomDtoMapper dtoMapper = new ClassroomDtoMapper();
+    @Mock
+    private TeacherDtoMapper teacherDtoMapper;
+
+    @InjectMocks
+    private ClassroomDtoMapper dtoMapper;
 
     @Test
     void asEntity() {
@@ -28,6 +41,10 @@ class ClassroomDtoMapperTest {
 
     @Test
     void asResultDto() {
+        // Given
+        given(teacherDtoMapper.asResultDto(any(Teacher.class)))
+            .willReturn(aTeacherResultDto().withId(2L));
+
         // When
         Classroom entity = Classroom.builder()
             .name("test name")

--- a/src/test/java/kr/pullgo/pullgoserver/dto/mapper/ClassroomDtoMapperTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/dto/mapper/ClassroomDtoMapperTest.java
@@ -42,7 +42,7 @@ class ClassroomDtoMapperTest {
         assertThat(dto.getId()).isEqualTo(0L);
         assertThat(dto.getName()).isEqualTo("test name");
         assertThat(dto.getAcademyId()).isEqualTo(1L);
-        assertThat(dto.getCreatorId()).isEqualTo(2L);
+        assertThat(dto.getCreator().getId()).isEqualTo(2L);
     }
 
 }

--- a/src/test/java/kr/pullgo/pullgoserver/helper/ClassroomHelper.java
+++ b/src/test/java/kr/pullgo/pullgoserver/helper/ClassroomHelper.java
@@ -2,6 +2,7 @@ package kr.pullgo.pullgoserver.helper;
 
 import static kr.pullgo.pullgoserver.helper.AcademyHelper.anAcademy;
 import static kr.pullgo.pullgoserver.helper.TeacherHelper.aTeacher;
+import static kr.pullgo.pullgoserver.helper.TeacherHelper.aTeacherResultDto;
 
 import kr.pullgo.pullgoserver.dto.ClassroomDto;
 import kr.pullgo.pullgoserver.persistence.model.Classroom;
@@ -38,7 +39,7 @@ public class ClassroomHelper {
         return ClassroomDto.Result.builder()
             .id(0L)
             .academyId(0L)
-            .creatorId(0L)
+            .creator(aTeacherResultDto())
             .name(ARBITRARY_NAME)
             .build();
     }


### PR DESCRIPTION
### get API 반환값의  creatorId 를 creator로 변경
기존의 방식은 creator의 fullName변경시 classroom의 name을 같이 변경해주는데 효과적이지 못했다.
classroom의 name 양식에서 creatorFullName을 제거하고, creator를 통해 fullName을 따로 받게된다면 creator의 변화에 조금 더 유연할것으로 예상된다.