### PR TITLE
엔티티와 달랐던 Dto의 검증 애노테이션 수정

### DIFF
--- a/src/main/java/kr/pullgo/pullgoserver/dto/AcademyDto.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/AcademyDto.java
@@ -1,5 +1,6 @@
 package kr.pullgo.pullgoserver.dto;
 
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
@@ -13,13 +14,13 @@ public interface AcademyDto {
     @With
     class Create {
 
-        @NotNull
+        @NotEmpty
         private String name;
 
-        @NotNull
+        @NotEmpty
         private String phone;
 
-        @NotNull
+        @NotEmpty
         private String address;
 
         @NotNull
@@ -48,13 +49,13 @@ public interface AcademyDto {
         @NotNull
         private Long id;
 
-        @NotNull
+        @NotEmpty
         private String name;
 
-        @NotNull
+        @NotEmpty
         private String phone;
 
-        @NotNull
+        @NotEmpty
         private String address;
 
         @NotNull
@@ -83,7 +84,6 @@ public interface AcademyDto {
 
         @NotNull
         private Long teacherId;
-
 
         public KickTeacher(@NotNull Long teacherId) {
             this.teacherId = teacherId;

--- a/src/main/java/kr/pullgo/pullgoserver/dto/AccountDto.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/AccountDto.java
@@ -1,5 +1,6 @@
 package kr.pullgo.pullgoserver.dto;
 
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import kr.pullgo.pullgoserver.persistence.model.UserRole;
 import lombok.Builder;
@@ -13,16 +14,16 @@ public interface AccountDto {
     @With
     class Create {
 
-        @NotNull
+        @NotEmpty
         private String username;
 
-        @NotNull
+        @NotEmpty
         private String password;
 
-        @NotNull
+        @NotEmpty
         private String fullName;
 
-        @NotNull
+        @NotEmpty
         private String phone;
     }
 
@@ -43,16 +44,16 @@ public interface AccountDto {
     @With
     class Result {
 
-        @NotNull
+        @NotEmpty
         private String username;
 
-        @NotNull
+        @NotEmpty
         private String fullName;
 
-        @NotNull
+        @NotEmpty
         private String phone;
 
-        @NotNull
+        @NotEmpty
         private UserRole role;
     }
 

--- a/src/main/java/kr/pullgo/pullgoserver/dto/AttenderAnswerDto.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/AttenderAnswerDto.java
@@ -1,6 +1,7 @@
 package kr.pullgo.pullgoserver.dto;
 
 import java.util.Set;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
@@ -20,7 +21,7 @@ public interface AttenderAnswerDto {
         @NotNull
         private Long questionId;
 
-        @NotNull
+        @NotEmpty
         private Set<Integer> answer;
     }
 
@@ -51,7 +52,7 @@ public interface AttenderAnswerDto {
         @NotNull
         private Long questionId;
 
-        @NotNull
+        @NotEmpty
         private Set<Integer> answer;
     }
 
@@ -61,7 +62,7 @@ public interface AttenderAnswerDto {
     @With
     class Put {
 
-        @NotNull
+        @NotEmpty
         private Set<Integer> answer;
 
         public Put(Set<Integer> answer) {

--- a/src/main/java/kr/pullgo/pullgoserver/dto/AuthDto.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/AuthDto.java
@@ -1,6 +1,6 @@
 package kr.pullgo.pullgoserver.dto;
 
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotEmpty;
 import lombok.Builder;
 import lombok.Data;
 
@@ -10,10 +10,10 @@ public interface AuthDto {
     @Builder
     class GenerateToken {
 
-        @NotNull
+        @NotEmpty
         private String username;
 
-        @NotNull
+        @NotEmpty
         private String password;
 
     }
@@ -22,7 +22,7 @@ public interface AuthDto {
     @Builder
     class GenerateTokenResult {
 
-        @NotNull
+        @NotEmpty
         private String token;
 
         private StudentDto.Result student;

--- a/src/main/java/kr/pullgo/pullgoserver/dto/ClassroomDto.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/ClassroomDto.java
@@ -1,5 +1,6 @@
 package kr.pullgo.pullgoserver.dto;
 
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
@@ -13,7 +14,7 @@ public interface ClassroomDto {
     @With
     class Create {
 
-        @NotNull
+        @NotEmpty
         private String name;
 
         @NotNull
@@ -47,7 +48,7 @@ public interface ClassroomDto {
         @NotNull
         private Long academyId;
 
-        @NotNull
+        @NotEmpty
         private String name;
 
         @NotNull

--- a/src/main/java/kr/pullgo/pullgoserver/dto/ExamDto.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/ExamDto.java
@@ -2,6 +2,7 @@ package kr.pullgo.pullgoserver.dto;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
@@ -20,7 +21,7 @@ public interface ExamDto {
         @NotNull
         private Long creatorId;
 
-        @NotNull
+        @NotEmpty
         private String name;
 
         @NotNull
@@ -65,7 +66,7 @@ public interface ExamDto {
         @NotNull
         private Long creatorId;
 
-        @NotNull
+        @NotEmpty
         private String name;
 
         @NotNull

--- a/src/main/java/kr/pullgo/pullgoserver/dto/LessonDto.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/LessonDto.java
@@ -1,5 +1,6 @@
 package kr.pullgo.pullgoserver.dto;
 
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
@@ -15,7 +16,7 @@ public interface LessonDto {
         @NotNull
         private Long classroomId;
 
-        @NotNull
+        @NotEmpty
         private String name;
 
         @NotNull
@@ -43,7 +44,7 @@ public interface LessonDto {
         @NotNull
         private Long classroomId;
 
-        @NotNull
+        @NotEmpty
         private String name;
 
         @NotNull

--- a/src/main/java/kr/pullgo/pullgoserver/dto/QuestionDto.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/QuestionDto.java
@@ -2,6 +2,7 @@ package kr.pullgo.pullgoserver.dto;
 
 import java.util.Map;
 import java.util.Set;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
@@ -17,15 +18,15 @@ public interface QuestionDto {
         @NotNull
         private Long examId;
 
-        @NotNull
+        @NotEmpty
         private String content;
 
         private String pictureUrl;
 
-        @NotNull
+        @NotEmpty
         private Set<Integer> answer;
 
-        @NotNull
+        @NotEmpty
         private Map<String, String> choice;
     }
 
@@ -54,15 +55,15 @@ public interface QuestionDto {
         @NotNull
         private Long examId;
 
-        @NotNull
+        @NotEmpty
         private String content;
 
         private String pictureUrl;
 
-        @NotNull
+        @NotEmpty
         private Set<Integer> answer;
 
-        @NotNull
+        @NotEmpty
         private Map<String, String> choice;
     }
 }

--- a/src/main/java/kr/pullgo/pullgoserver/dto/StudentDto.java
+++ b/src/main/java/kr/pullgo/pullgoserver/dto/StudentDto.java
@@ -1,5 +1,6 @@
 package kr.pullgo.pullgoserver.dto;
 
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
@@ -16,10 +17,10 @@ public interface StudentDto {
         @NotNull
         private AccountDto.Create account;
 
-        @NotNull
+        @NotEmpty
         private String parentPhone;
 
-        @NotNull
+        @NotEmpty
         private String schoolName;
 
         @NotNull
@@ -51,10 +52,10 @@ public interface StudentDto {
         @NotNull
         private AccountDto.Result account;
 
-        @NotNull
+        @NotEmpty
         private String parentPhone;
 
-        @NotNull
+        @NotEmpty
         private String schoolName;
 
         @NotNull


### PR DESCRIPTION
일부 NotNull을 NotEmpty로 수정해서 엔티티와 달리 Dto에서 빈 문자열이나 길이가 0인 Collection을 걸러낼 수 없었던 문제 해결