### PR TITLE
AttenderState create의 누락된 조건 추가

### DIFF
--- a/src/main/java/kr/pullgo/pullgoserver/persistence/repository/AttenderStateRepository.java
+++ b/src/main/java/kr/pullgo/pullgoserver/persistence/repository/AttenderStateRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AttenderStateRepository extends BaseRepository<AttenderState, Long> {
 
+    boolean existsFindByAttenderIdAndExamId(Long attenderId, Long ExamId);
 }

--- a/src/main/java/kr/pullgo/pullgoserver/service/AttenderStateService.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/AttenderStateService.java
@@ -46,6 +46,12 @@ public class AttenderStateService {
     @Transactional
     public AttenderStateDto.Result create(AttenderStateDto.Create dto,
         Authentication authentication) {
+
+        if (attenderStateRepository.existsFindByAttenderIdAndExamId(dto.getAttenderId(),
+            dto.getExamId())){
+            throw errorHelper.badRequest("Attender State already exists");
+        }
+
         AttenderState attenderState = AttenderState.builder()
             .examStartTime(LocalDateTime.now())
             .build();
@@ -56,6 +62,9 @@ public class AttenderStateService {
         attenderState.setAttender(dtoAttender);
 
         Exam dtoExam = repoHelper.findExamOrThrow(dto.getExamId());
+        if (dtoExam.getQuestions().isEmpty()){
+            throw errorHelper.badRequest("There is no question in exam");
+        }
         attenderState.setExam(dtoExam);
 
         return dtoMapper.asResultDto(attenderStateRepository.save(attenderState));


### PR DESCRIPTION
## Question이 없는 Exam에 응시하지 못하도록 변경

exam을 자동으로 종료해주는 examFinishJob CRON 작업중 Exam에 응시중인 AttenderState를 채점하는 과정에서, 
문제가 존재하지 않는 Exam에 응시한 AttenderState를 채점하는 과정에서 발생하는 AttenderStateSubmitOnNoQuestionsOnExamException를 처리하지 못했던 문제를 Question이 없는 Exam에 학생이 응시하지 못하도록 AttenderState를 생성하지 못하는 방향으로 해결 
****
기타 내용은 커밋과 같음