### PR TITLE
Question Patch bulk API 추가

### DIFF
--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -787,6 +787,14 @@ operation::questions-create-example[snippets='request-fields,curl-request,http-r
 
 operation::question-update-example[snippets='request-fields,curl-request,http-response']
 
+[[resources_questions_upate]]
+=== Question 다중 수정
+
+`PATCH /exam/questions/bulk` 요청으로 Question들을 수정합니다.
+요청의 `Authorization` 헤더로 요청을 보낸 `Teacher` 의 엑세스 토큰이 제공되어야 합니다.
+
+operation::questions-update-example[snippets='request-fields,curl-request,http-response']
+
 [[resources_question_delete]]
 === Question 삭제
 

--- a/src/main/java/kr/pullgo/pullgoserver/presentation/controller/QuestionController.java
+++ b/src/main/java/kr/pullgo/pullgoserver/presentation/controller/QuestionController.java
@@ -1,6 +1,7 @@
 package kr.pullgo.pullgoserver.presentation.controller;
 
 import java.util.List;
+import java.util.Map;
 import javax.validation.Valid;
 import kr.pullgo.pullgoserver.dto.QuestionDto;
 import kr.pullgo.pullgoserver.persistence.model.Question;
@@ -77,4 +78,9 @@ public class QuestionController {
         return questionService.update(id, dto, authentication);
     }
 
+    @PatchMapping("/exam/questions/bulk")
+    public void patch(
+        @Valid @RequestBody Map<Long, QuestionDto.Update> dtos, Authentication authentication) {
+        questionService.update(dtos, authentication);
+    }
 }

--- a/src/main/java/kr/pullgo/pullgoserver/service/QuestionService.java
+++ b/src/main/java/kr/pullgo/pullgoserver/service/QuestionService.java
@@ -1,6 +1,7 @@
 package kr.pullgo.pullgoserver.service;
 
 import java.util.List;
+import java.util.Map;
 import kr.pullgo.pullgoserver.dto.QuestionDto;
 import kr.pullgo.pullgoserver.dto.mapper.QuestionDtoMapper;
 import kr.pullgo.pullgoserver.persistence.model.Answer;
@@ -88,6 +89,14 @@ public class QuestionService {
             entity.setMultipleChoice(new MultipleChoice(dto.getChoice()));
         }
         return dtoMapper.asResultDto(questionRepository.save(entity));
+    }
+
+    @Transactional
+    public void update(Map<Long, QuestionDto.Update> dtos,
+        Authentication authentication) {
+        for (var id : dtos.keySet()) {
+            update(id, dtos.get(id), authentication);
+        }
     }
 
     @Transactional

--- a/src/test/java/kr/pullgo/pullgoserver/QuestionIntegrationTest.java
+++ b/src/test/java/kr/pullgo/pullgoserver/QuestionIntegrationTest.java
@@ -71,7 +71,8 @@ public class QuestionIntegrationTest {
     private static final FieldDescriptor DOC_FIELD_ANSWER =
         fieldWithPath("answer").description("정답 (객관식, 1~5 범위의 정수 배열)");
     private static final FieldDescriptor DOC_FIELD_MULTIPLE_CHOICE =
-        subsectionWithPath("choice").type("MultipleChoice").description("객관식 보기 (1~5 범위의 정수, 보기 내용)");
+        subsectionWithPath("choice").type("MultipleChoice")
+            .description("객관식 보기 (1~5 범위의 정수, 보기 내용)");
     private static final FieldDescriptor DOC_FIELD_PICTURE_URL =
         fieldWithPath("pictureUrl").description("첨부된 사진의 URL");
     private static final FieldDescriptor DOC_FIELD_CONTENT =
@@ -80,6 +81,10 @@ public class QuestionIntegrationTest {
         fieldWithPath("examId").description("소속된 시험 ID");
     private static final FieldDescriptor DOC_FIELD_QUESTIONS =
         subsectionWithPath(".[*]").type("Question").description("Question 생성 필요필드와 동일");
+    private static final FieldDescriptor DOC_FIELD_PATCH_QUESTIONS_ID =
+        subsectionWithPath("*").type("Long").description("Question 의 ID");
+    private static final FieldDescriptor DOC_FIELD_PATCH_QUESTIONS =
+        subsectionWithPath("*.*").type("Question").description("Question 수정 필드와 동일");
 
     private MockMvc mockMvc;
 
@@ -524,6 +529,13 @@ public class QuestionIntegrationTest {
             // Then
             actions
                 .andExpect(status().isOk());
+
+            // Document
+            actions.andDo(document("questions-update-example",
+                requestFields(
+                    DOC_FIELD_PATCH_QUESTIONS_ID,
+                    DOC_FIELD_PATCH_QUESTIONS
+                )));
         }
 
         @Test


### PR DESCRIPTION
클라이언트의 요구사항에 따라 모든 Question에 대한 Patch가 성공해야 전체 bulk Patch가 성공하도록, 그에따른 응답은 성공 실패 여부만 알 수 있도록 구현

Map을 사용해 Question의 Id를 Map의 Key로 Question의 수정사항은 Map의 Value로 받도록 구현