### PR TITLE
도메인 변경으로 인한 API Guide URL 변경

### DIFF
--- a/src/test/java/kr/pullgo/pullgoserver/docs/ApiDocumentation.java
+++ b/src/test/java/kr/pullgo/pullgoserver/docs/ApiDocumentation.java
@@ -77,9 +77,9 @@ public class ApiDocumentation {
         RestDocumentationContextProvider restDocumentation) {
         var baseUriOperationPreprocessor = new BaseUriOperationPreprocessor()
             .scheme("https")
-            .host("api.pullgo.kr")
+            .host("pullgo.firstian.kr")
             .removePort()
-            .basePath("/v1");
+            .basePath("/api/v1");
         return documentationConfiguration(restDocumentation)
             .operationPreprocessors()
             .withRequestDefaults(baseUriOperationPreprocessor)


### PR DESCRIPTION
 API Guide URL을 
https://api.pullgo.kr/v1/ 에서 https://pullgo.firstian.kr/api/v1/ 로 변경